### PR TITLE
Remove redundant information from the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 - [General](#general)
   - [Semantic Versioning](#semantic-versioning)
   - [Unstable Features](#unstable-features)
-  - [Colored Output](#colored-output)
 - [Bittorrent](#bittorrent)
   - [BEP Support](#bep-support)
 
@@ -26,27 +25,9 @@ In particular:
 ### Unstable Features
 
 To avoid premature stabilization and excessive version churn, unstable features
-are unavailable unless the `--unstable` / `-u` flag is passed. Unstable
-features may be changed or removed at any time.
-
-```
-$ imdl torrent stats --input tmp
-error: Feature `torrent stats subcommand` cannot be used without passing the `--unstable` flag
-$ imdl --unstable torrent stats tmp
-Torrents processed: 0
-Read failed:        0
-Decode failed:      0
-```
-
-### Colored Output
-
-Intermodal features colored help, error, and informational output. Colored
-output is disabled if Intermodal detects that it is not printing to a TTY.
-
-To disable colored output, set the `NO_COLOR` environment variable to any
-value or pass `--use-color never` on the command line.
-
-To force colored output, pass `--use-color always` on the command line.
+are unavailable unless the `--unstable` / `-u` flag is passed, for example
+`imdl --unstable torrent create .`. Unstable features may be changed or removed
+at any time.
 
 ## Bittorrent
 


### PR DESCRIPTION
The removed information was added to help messages, so it was redundant. Fixes #77.