### PR TITLE
Add `install` script and installation section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 ## Manual
 
 - [General](#general)
+  - [Installation](#installation)
+    - [Supported Operating Systems](#supported-operating-systems)
+    - [Pre-built binaries](#pre-built-binaries)
+    - [crates.io](#crates.io)
   - [Semantic Versioning](#semantic-versioning)
   - [Unstable Features](#unstable-features)
 - [Bittorrent](#bittorrent)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   - [Installation](#installation)
     - [Supported Operating Systems](#supported-operating-systems)
     - [Pre-built binaries](#pre-built-binaries)
-    - [crates.io](#crates.io)
+    - [Cargo](#cargo)
   - [Semantic Versioning](#semantic-versioning)
   - [Unstable Features](#unstable-features)
 - [Bittorrent](#bittorrent)
@@ -39,10 +39,11 @@ curl --proto '=https' --tlsv1.2 -sSf \
   | bash -s -- --to DEST
 ```
 
-#### crates.io
+#### Cargo
 
-`imdl` is published to [crates.io](https://crates.io), and can be installed
-using cargo with `cargo install imdl`.
+`imdl` is written in [Rust](https://www.rust-lang.org/) and can be built from
+source and installed with `cargo install imdl`. To get Rust, use the
+[rustup installer](https://rustup.rs/).
 
 ### Semantic Versioning
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,34 @@
 
 ## General
 
+### Installation
+
+#### Supported Operating Systems
+
+`imdl` supports both unix and Windows. It is tested on Linux, MacOS, and
+Windows, but should work on other unix OSs. If it does not, please open an
+issue!
+
+#### Pre-built binaries
+
+Pre-built binaries for Linux, macOS, and Windows can be found on
+[the releases page](https://github.com/casey/intermodal/releases).
+
+You can use the following command to download the latest binary for Linux,
+MacOS or Windows, just replace `DEST` with the directory where you'd like to
+install the `imdl` binary:
+
+```sh
+curl --proto '=https' --tlsv1.2 -sSf \
+  https://raw.githubusercontent.com/casey/intermodal/master/bin/install \
+  | bash -s -- --to DEST
+```
+
+#### crates.io
+
+`imdl` is published to [crates.io](https://crates.io), and can be installed
+using cargo with `cargo install imdl`.
+
 ### Semantic Versioning
 
 Intermodal follows [semantic versioning](https://semver.org/).

--- a/bin/install
+++ b/bin/install
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+set -eu
+
+help() {
+  cat <<'EOF'
+Install a binary release of a imdl hosted on GitHub
+
+Usage:
+    install [options]
+
+Options:
+    -h, --help      Display this message
+    -f, --force     Force overwriting an existing binary
+    --tag TAG       Tag (version) of the crate to install (default <latest release>)
+    --to LOCATION   Where to install the binary (default ~/.cargo/bin)
+EOF
+}
+
+git=casey/intermodal
+crate=imdl
+url=https://github.com/casey/intermodal
+releases=$url/releases
+
+case `uname -s` in
+  Darwin) target=x86_64-apple-darwin;;
+  Linux)  target=x86_64-unknown-linux-musl;;
+  *)      target=x86_64-pc-windows-msvc;;
+esac
+
+say() {
+  echo "install: $1"
+}
+
+say_err() {
+  say "$1" >&2
+}
+
+err() {
+  if [ ! -z ${td-} ]; then
+    rm -rf $td
+  fi
+
+  say_err "ERROR $1"
+  exit 1
+}
+
+need() {
+  if ! command -v $1 > /dev/null 2>&1; then
+    err "need $1 (command not found)"
+  fi
+}
+
+force=false
+while test $# -gt 0; do
+  case $1 in
+    --force | -f)
+      force=true
+      ;;
+    --help | -h)
+      help
+      exit 0
+      ;;
+    --tag)
+      tag=$2
+      shift
+      ;;
+    --to)
+      dest=$2
+      shift
+      ;;
+    *)
+      ;;
+  esac
+  shift
+done
+
+# Dependencies
+need basename
+need curl
+need install
+need mkdir
+need mktemp
+need tar
+
+# Optional dependencies
+if [ -z ${tag-} ]; then
+  need cut
+  need rev
+fi
+
+if [ -z ${dest-} ]; then
+  dest="$HOME/.cargo/bin"
+fi
+
+if [ -z ${tag-} ]; then
+  tag=$(curl -s "$releases/latest" | cut -d'"' -f2 | rev | cut -d'/' -f1 | rev)
+fi
+
+archive="$releases/download/$tag/$crate-$tag-$target.tar.gz"
+
+say_err "Repository:  $url"
+say_err "Crate:       $crate"
+say_err "Tag:         $tag"
+say_err "Target:      $target"
+say_err "Destination: $dest"
+say_err "Archive:     $archive"
+
+td=$(mktemp -d || mktemp -d -t tmp)
+curl -sL $archive | tar -C $td -xz
+
+for f in $(ls $td); do
+  test -x $td/$f || continue
+
+  if [ -e "$dest/$f" ] && [ $force = false ]; then
+    err "$f already exists in $dest"
+  else
+    mkdir -p $dest
+    install -m 755 $td/$f $dest
+  fi
+done
+
+rm -rf $td

--- a/bin/update-readme/src/opt.rs
+++ b/bin/update-readme/src/opt.rs
@@ -31,7 +31,7 @@ impl Opt {
       let text = captures.name("TEXT").unwrap().as_str();
       let level = marker.len();
       let indentation = " ".repeat((level - 2) * 2);
-      let slug = text.to_lowercase().replace(' ', "-");
+      let slug = text.to_lowercase().replace(' ', "-").replace('.', "");
       toc.push(format!("{}- [{}](#{})", indentation, text, slug));
     }
 


### PR DESCRIPTION
- Add the install script from https://github.com/japaric/trust and customizes it for imdl.
- Add installation instructions to the readme.