### PR TITLE
Disable bors

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,4 +1,0 @@
-delete-merged-branches = true
-status                 = ["All (%-latest)"]
-use-squash-merge       = true
-cut-body-after         = "---"


### PR DESCRIPTION
Nits with bors:
- Replaced my name with my username
- Doesn't show merge requests as merged
- Adds "merged by bors" to PRs
- Generates tons of spam
- Doesn't sign commits
- Creates tons of spam CI runs