### PR TITLE
Add source to generated torrent with `--source`

### DIFF
--- a/src/info.rs
+++ b/src/info.rs
@@ -1,13 +1,14 @@
 use crate::common::*;
 
 #[derive(Deserialize, Serialize)]
-pub struct Info {
-  pub private: Option<u8>,
+pub(crate) struct Info {
+  pub(crate) private: Option<u8>,
   #[serde(rename = "piece length")]
-  pub piece_length: u32,
-  pub name: String,
+  pub(crate) piece_length: u32,
+  pub(crate) name: String,
+  pub(crate) source: Option<String>,
   #[serde(with = "serde_bytes")]
-  pub pieces: Vec<u8>,
+  pub(crate) pieces: Vec<u8>,
   #[serde(flatten)]
-  pub mode: Mode,
+  pub(crate) mode: Mode,
 }

--- a/src/metainfo.rs
+++ b/src/metainfo.rs
@@ -1,17 +1,17 @@
 use crate::common::*;
 
 #[derive(Deserialize, Serialize)]
-pub struct Metainfo {
-  pub announce: String,
+pub(crate) struct Metainfo {
+  pub(crate) announce: String,
   #[serde(rename = "announce-list")]
-  pub announce_list: Option<Vec<Vec<String>>>,
-  pub comment: Option<String>,
+  pub(crate) announce_list: Option<Vec<Vec<String>>>,
+  pub(crate) comment: Option<String>,
   #[serde(rename = "created by")]
-  pub created_by: Option<String>,
+  pub(crate) created_by: Option<String>,
   #[serde(rename = "creation date")]
-  pub creation_date: Option<u64>,
-  pub encoding: Option<String>,
-  pub info: Info,
+  pub(crate) creation_date: Option<u64>,
+  pub(crate) encoding: Option<String>,
+  pub(crate) info: Info,
 }
 
 impl Metainfo {

--- a/src/torrent/create.rs
+++ b/src/torrent/create.rs
@@ -103,6 +103,13 @@ Note: Many BitTorrent clients do not implement the behavior described in BEP 12.
     long_help = "Set the `private` flag. Torrent clients that understand the flag and participate in the swarm of a torrent with the flag set will only announce themselves to the announce URLs included in the torrent, and will not use other peer discovery mechanisms, such as the DHT or local peer discovery. See BEP 27: Private Torrents for more information."
   )]
   private: bool,
+  #[structopt(
+    name = "SOURCE",
+    long = "source",
+    help = "Include `SOURCE` in generated `.torrent` file.",
+    long_help = "Include `SOURCe` in generated `.torrent` file. Stored under `info.source` key of metainfo dictionary."
+  )]
+  source: Option<String>,
 }
 
 struct Linter {
@@ -218,6 +225,7 @@ impl Create {
     let (mode, pieces) = Hasher::hash(&input, self.md5sum, piece_length)?;
 
     let info = Info {
+      source: self.source,
       piece_length,
       mode,
       pieces,

--- a/src/torrent/show.rs
+++ b/src/torrent/show.rs
@@ -29,6 +29,8 @@ impl Show {
 mod tests {
   use super::*;
 
+  use pretty_assertions::assert_eq;
+
   #[test]
   fn output() {
     let mut env = testing::env(
@@ -47,6 +49,7 @@ mod tests {
       info: Info {
         private: Some(1),
         piece_length: 16 * 1024,
+        source: Some("source".into()),
         name: "foo".into(),
         pieces: vec![
           0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
@@ -68,8 +71,9 @@ mod tests {
     let want = "        Name  foo
      Comment  comment
      Created  1970-01-01 00:00:01 UTC
-   Info Hash  bd68a8a5ab377e37e8cdbfd37b670408c59a009f
-Torrent Size  236 bytes
+      Source  source
+   Info Hash  b7595205a46491b3e8686e10b28efe7144d066cc
+Torrent Size  252 bytes
 Content Size  20 bytes
      Private  yes
     Trackers  Main:   announce

--- a/src/torrent_summary.rs
+++ b/src/torrent_summary.rs
@@ -75,6 +75,10 @@ impl TorrentSummary {
       );
     }
 
+    if let Some(source) = &self.metainfo.info.source {
+      table.row("Source", source);
+    }
+
     table.row("Info Hash", self.infohash);
 
     table.row("Torrent Size", self.size);


### PR DESCRIPTION
Support adding a `source` key under the `info` dictionary. The `source`
key is commonly used to create distinct torrents for different trackers.

Fixes #106.