### PR TITLE
Skip hidden files, symlinks, and junk in created torrents 

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -82,6 +82,11 @@ pub(crate) enum Error {
   Stderr { source: io::Error },
   #[snafu(display("Failed to write to standard output: {}", source))]
   Stdout { source: io::Error },
+  #[snafu(display(
+      "Attempted to create torrent from symlink `{}`. To override, pass the `--follow-symlinks` flag.",
+      root.display()
+  ))]
+  SymlinkRoot { root: PathBuf },
   #[snafu(display("Failed to retrieve system time: {}", source))]
   SystemTime { source: SystemTimeError },
   #[snafu(display(

--- a/src/file_path.rs
+++ b/src/file_path.rs
@@ -1,7 +1,7 @@
 use crate::common::*;
 
 #[serde(transparent)]
-#[derive(Deserialize, Serialize, Debug, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
 pub(crate) struct FilePath {
   components: Vec<String>,
 }
@@ -43,6 +43,18 @@ impl FilePath {
     }
 
     Ok(FilePath { components })
+  }
+
+  pub(crate) fn name(&self) -> &str {
+    &self.components[0]
+  }
+
+  pub(crate) fn absolute(&self, root: &Path) -> PathBuf {
+    let mut absolute = root.to_owned();
+    for component in &self.components {
+      absolute.push(component);
+    }
+    absolute
   }
 
   #[cfg(test)]

--- a/src/files.rs
+++ b/src/files.rs
@@ -3,15 +3,32 @@ use crate::common::*;
 pub(crate) struct Files {
   root: PathBuf,
   total_size: Bytes,
+  contents: Option<Vec<FilePath>>,
 }
 
 impl Files {
-  pub(crate) fn new(root: PathBuf, total_size: Bytes) -> Files {
-    Files { root, total_size }
+  pub(crate) fn file(root: PathBuf, total_size: Bytes) -> Files {
+    Files {
+      contents: None,
+      root,
+      total_size,
+    }
+  }
+
+  pub(crate) fn dir(root: PathBuf, total_size: Bytes, contents: Vec<FilePath>) -> Files {
+    Files {
+      contents: Some(contents),
+      root,
+      total_size,
+    }
   }
 
   pub(crate) fn root(&self) -> &Path {
     &self.root
+  }
+
+  pub(crate) fn contents(&self) -> Option<&[FilePath]> {
+    self.contents.as_deref()
   }
 
   pub(crate) fn total_size(&self) -> Bytes {

--- a/src/opt/torrent/create.rs
+++ b/src/opt/torrent/create.rs
@@ -1189,6 +1189,7 @@ Content Size  9 bytes
   }
 
   #[test]
+  #[cfg(unix)]
   fn follow_symlinks() {
     let mut env = environment(&[
       "--input",

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -22,6 +22,14 @@ impl TestEnv {
   pub(crate) fn out_bytes(&self) -> Vec<u8> {
     self.out.bytes()
   }
+
+  pub(crate) fn create_dir(&self, path: impl AsRef<Path>) {
+    fs::create_dir_all(self.env.resolve(path.as_ref())).unwrap();
+  }
+
+  pub(crate) fn create_file(&self, path: impl AsRef<Path>, bytes: impl AsRef<[u8]>) {
+    fs::write(self.env.resolve(path), bytes.as_ref()).unwrap();
+  }
 }
 
 impl Deref for TestEnv {

--- a/src/walker.rs
+++ b/src/walker.rs
@@ -1,41 +1,72 @@
 use crate::common::*;
 
+const JUNK: &[&str] = &["Thumbs.db", "Desktop.ini"];
+
 pub(crate) struct Walker {
-  include_junk: bool,
+  follow_symlinks: bool,
   include_hidden: bool,
+  include_junk: bool,
   root: PathBuf,
 }
 
 impl Walker {
   pub(crate) fn new(root: &Path) -> Walker {
     Walker {
-      include_junk: false,
+      follow_symlinks: false,
       include_hidden: false,
+      include_junk: false,
       root: root.to_owned(),
     }
   }
 
-  pub(crate) fn _include_junk(self) -> Self {
+  pub(crate) fn include_junk(self, include_junk: bool) -> Self {
     Walker {
-      include_junk: true,
+      include_junk,
       ..self
     }
   }
 
-  pub(crate) fn _include_hidden(self) -> Self {
+  pub(crate) fn include_hidden(self, include_hidden: bool) -> Self {
     Walker {
-      include_hidden: true,
+      include_hidden,
+      ..self
+    }
+  }
+
+  pub(crate) fn follow_symlinks(self, follow_symlinks: bool) -> Self {
+    Walker {
+      follow_symlinks,
       ..self
     }
   }
 
   pub(crate) fn files(self) -> Result<Files, Error> {
+    if !self.follow_symlinks
+      && self
+        .root
+        .symlink_metadata()
+        .context(error::Filesystem { path: &self.root })?
+        .file_type()
+        .is_symlink()
+    {
+      return Err(Error::SymlinkRoot { root: self.root });
+    }
+
+    let root_metadata = self
+      .root
+      .metadata()
+      .context(error::Filesystem { path: &self.root })?;
+
+    if root_metadata.is_file() {
+      return Ok(Files::file(self.root, Bytes::from(root_metadata.len())));
+    }
+
     let mut paths = Vec::new();
     let mut total_size = 0;
-
-    let junk: &[&OsStr] = &[OsStr::new("Thumbs.db"), OsStr::new("Desktop.ini")];
-
-    for result in WalkDir::new(&self.root).sort_by(|a, b| a.file_name().cmp(b.file_name())) {
+    for result in WalkDir::new(&self.root)
+      .follow_links(self.follow_symlinks)
+      .sort_by(|a, b| a.file_name().cmp(b.file_name()))
+    {
       let entry = result?;
 
       let path = entry.path();
@@ -56,14 +87,17 @@ impl Walker {
         continue;
       }
 
-      if !self.include_junk && junk.contains(&file_name) {
+      let file_path = FilePath::from_prefix_and_path(&self.root, &path)?;
+
+      if !self.include_junk && JUNK.contains(&file_path.name()) {
         continue;
       }
 
       total_size += metadata.len();
-      paths.push(entry.path().to_owned());
+
+      paths.push(file_path);
     }
 
-    Ok(Files::new(self.root, Bytes::from(total_size)))
+    Ok(Files::dir(self.root, Bytes::from(total_size), paths))
   }
 }


### PR DESCRIPTION
By default, skip the following when creating a torrent:

- Junk files, like `Thumbs.db`
- Files and directories that begin with a `.`
- Files and directories that have the OS or Windows hidden attribute set
- Symlinks

These can be overridden with, respectively:
- `--include-junk`
- `--include-hidden`
- `--include-hidden`
- `--follow-symlinks`