### PR TITLE
Show files in single-file mode

### DIFF
--- a/justfile
+++ b/justfile
@@ -11,6 +11,10 @@ stats PATH:
 	cargo build --release
 	time ./target/release/imdl --unstable torrent stats --input {{PATH}}
 
+push: check
+	! git branch | grep '* master'
+	git push github
+
 # clean up feature branch BRANCH
 done BRANCH:
 	git checkout master

--- a/src/opt/torrent/show.rs
+++ b/src/opt/torrent/show.rs
@@ -84,6 +84,7 @@ Content Size  20 bytes
   Piece Size  16 KiB
  Piece Count  1
   File Count  1
+       Files  foo
 ";
 
       assert_eq!(have, want);
@@ -115,6 +116,7 @@ Trackers\tannounce\tb\tc
 Piece Size\t16384
 Piece Count\t1
 File Count\t1
+Files\tfoo
 ";
 
       assert_eq!(have, want);

--- a/src/torrent_summary.rs
+++ b/src/torrent_summary.rs
@@ -130,7 +130,10 @@ impl TorrentSummary {
     table.row("Piece Count", self.metainfo.info.pieces.len() / 20);
 
     match &self.metainfo.info.mode {
-      Mode::Single { .. } => table.row("File Count", 1),
+      Mode::Single { .. } => {
+        table.row("File Count", 1);
+        table.row("Files", &self.metainfo.info.name);
+      }
       Mode::Multiple { files } => {
         table.row("File Count", files.len());
         table.directory(


### PR DESCRIPTION
Since it may be useful for scripting purposes, show file list, even for
single-file torrents.