### PR TITLE
Test creating torrents from `.` and `..`

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -2,7 +2,7 @@ use crate::common::*;
 
 pub(crate) struct Env {
   args: Vec<OsString>,
-  dir: Box<dyn AsRef<Path>>,
+  dir: PathBuf,
   pub(crate) err: Box<dyn Write>,
   pub(crate) out: Box<dyn Write>,
   err_style: Style,
@@ -63,8 +63,8 @@ impl Env {
     args.run(self)
   }
 
-  pub(crate) fn new<D, O, E, S, I>(
-    dir: D,
+  pub(crate) fn new<O, E, S, I>(
+    dir: PathBuf,
     out: O,
     out_style: Style,
     out_is_term: bool,
@@ -73,7 +73,6 @@ impl Env {
     args: I,
   ) -> Self
   where
-    D: AsRef<Path> + 'static,
     O: Write + 'static,
     E: Write + 'static,
     S: Into<OsString>,
@@ -81,9 +80,9 @@ impl Env {
   {
     Self {
       args: args.into_iter().map(Into::into).collect(),
-      dir: Box::new(dir),
       err: Box::new(err),
       out: Box::new(out),
+      dir,
       out_style,
       out_is_term,
       err_style,
@@ -133,7 +132,7 @@ impl Env {
   }
 
   pub(crate) fn dir(&self) -> &Path {
-    self.dir.as_ref().as_ref()
+    &self.dir
   }
 
   pub(crate) fn resolve(&self, path: impl AsRef<Path>) -> PathBuf {

--- a/src/subcommand/torrent/create.rs
+++ b/src/subcommand/torrent/create.rs
@@ -382,6 +382,56 @@ mod tests {
   }
 
   #[test]
+  fn input_dot() {
+    let mut env = test_env! {
+      args: [
+        "torrent",
+        "create",
+        "--input",
+        ".",
+        "--announce",
+        "https://bar",
+      ],
+      cwd: "dir",
+      tree: {
+        dir: {
+          foo: "",
+        },
+      }
+    };
+    env.run().unwrap();
+    let metainfo = env.load_metainfo("../dir.torrent");
+    assert_eq!(metainfo.info.name, "dir");
+    assert_matches!(metainfo.info.mode, Mode::Multiple{files} if files.len() == 1);
+  }
+
+  #[test]
+  fn input_dot_dot() {
+    let mut env = test_env! {
+      args: [
+        "torrent",
+        "create",
+        "--input",
+        "..",
+        "--announce",
+        "https://bar",
+      ],
+      cwd: "a/b",
+      tree: {
+        a: {
+          b: {
+            foo: "",
+          },
+        },
+      }
+    };
+    env.run().unwrap();
+    let metainfo = env.load_metainfo("../../a.torrent");
+    assert_eq!(metainfo.info.name, "a");
+    assert_matches!(metainfo.info.mode, Mode::Multiple{files} if files.len() == 1);
+  }
+
+  #[test]
   fn privacy_defaults_to_false() {
     let mut env = test_env! {
       args: ["torrent", "create", "--input", "foo", "--announce", "https://bar"],

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -3,6 +3,7 @@ use crate::common::*;
 macro_rules! test_env {
   {
     args: [$($arg:expr),* $(,)?],
+    $(cwd: $cwd:expr,)?
     tree: {
       $($tree:tt)*
     } $(,)?
@@ -11,6 +12,7 @@ macro_rules! test_env {
       let tempdir = temptree! { $($tree)* };
 
       TestEnvBuilder::new()
+        $(.current_dir(tempdir.path().join($cwd)))?
         .tempdir(tempdir)
         .arg("imdl")
         $(.arg($arg))*
@@ -21,13 +23,20 @@ macro_rules! test_env {
 
 pub(crate) struct TestEnv {
   env: Env,
+  #[allow(unused)]
+  tempdir: TempDir,
   err: Capture,
   out: Capture,
 }
 
 impl TestEnv {
-  pub(crate) fn new(env: Env, err: Capture, out: Capture) -> TestEnv {
-    Self { err, env, out }
+  pub(crate) fn new(tempdir: TempDir, env: Env, err: Capture, out: Capture) -> TestEnv {
+    Self {
+      tempdir,
+      err,
+      env,
+      out,
+    }
   }
 
   pub(crate) fn err(&self) -> String {


### PR DESCRIPTION
Test that torrent gets actual name of directory, and is created in the
correct location.

Fixes #8.