### PR TITLE
Make table names more greppable

### DIFF
--- a/src/subcommand/torrent/show.rs
+++ b/src/subcommand/torrent/show.rs
@@ -72,25 +72,25 @@ mod tests {
       env.run().unwrap();
 
       let have = env.out();
-      let want = "        Name  foo
-     Comment  comment
-     Created  1970-01-01 00:00:01 UTC
-  Created By  created by
-      Source  source
-   Info Hash  e12253978dc6d50db11d05747abcea1ad03b51c5
-Torrent Size  339 bytes
-Content Size  20 bytes
-     Private  yes
-    Trackers  Tier 1: announce
-                      b
-              Tier 2: c
-   DHT Nodes  x:12
-              1.1.1.1:16
-              [2001:db8:85a3::8a2e:370]:7334
-  Piece Size  16 KiB
- Piece Count  2
-  File Count  1
-       Files  foo
+      let want = "         Name  foo
+      Comment  comment
+Creation Date  1970-01-01 00:00:01 UTC
+   Created By  created by
+       Source  source
+    Info Hash  e12253978dc6d50db11d05747abcea1ad03b51c5
+ Torrent Size  339 bytes
+ Content Size  20 bytes
+      Private  yes
+     Trackers  Tier 1: announce
+                       b
+               Tier 2: c
+    DHT Nodes  x:12
+               1.1.1.1:16
+               [2001:db8:85a3::8a2e:370]:7334
+   Piece Size  16 KiB
+  Piece Count  2
+   File Count  1
+        Files  foo
 ";
 
       assert_eq!(have, want);
@@ -109,21 +109,21 @@ Content Size  20 bytes
 
       let have = env.out();
       let want = "\
-Name\tfoo
-Comment\tcomment
-Created\t1970-01-01 00:00:01 UTC
-Created By\tcreated by
-Source\tsource
-Info Hash\te12253978dc6d50db11d05747abcea1ad03b51c5
-Torrent Size\t339
-Content Size\t20
-Private\tyes
-Trackers\tannounce\tb\tc
-DHT Nodes\tx:12\t1.1.1.1:16\t[2001:db8:85a3::8a2e:370]:7334
-Piece Size\t16384
-Piece Count\t2
-File Count\t1
-Files\tfoo
+name\tfoo
+comment\tcomment
+creation date\t1970-01-01 00:00:01 UTC
+created by\tcreated by
+source\tsource
+info hash\te12253978dc6d50db11d05747abcea1ad03b51c5
+torrent size\t339
+content size\t20
+private\tyes
+trackers\tannounce\tb\tc
+dht nodes\tx:12\t1.1.1.1:16\t[2001:db8:85a3::8a2e:370]:7334
+piece size\t16384
+piece count\t2
+file count\t1
+files\tfoo
 ";
 
       assert_eq!(have, want);
@@ -170,26 +170,26 @@ Files\tfoo
       env.run().unwrap();
 
       let have = env.out();
-      let want = "        Name  foo
-     Comment  comment
-     Created  1970-01-01 00:00:01 UTC
-  Created By  created by
-      Source  source
-   Info Hash  e12253978dc6d50db11d05747abcea1ad03b51c5
-Torrent Size  327 bytes
-Content Size  20 bytes
-     Private  yes
-    Trackers  a
-              x
-              y
-              z
-   DHT Nodes  x:12
-              1.1.1.1:16
-              [2001:db8:85a3::8a2e:370]:7334
-  Piece Size  16 KiB
- Piece Count  2
-  File Count  1
-       Files  foo
+      let want = "         Name  foo
+      Comment  comment
+Creation Date  1970-01-01 00:00:01 UTC
+   Created By  created by
+       Source  source
+    Info Hash  e12253978dc6d50db11d05747abcea1ad03b51c5
+ Torrent Size  327 bytes
+ Content Size  20 bytes
+      Private  yes
+     Trackers  a
+               x
+               y
+               z
+    DHT Nodes  x:12
+               1.1.1.1:16
+               [2001:db8:85a3::8a2e:370]:7334
+   Piece Size  16 KiB
+  Piece Count  2
+   File Count  1
+        Files  foo
 ";
 
       assert_eq!(have, want);
@@ -208,21 +208,21 @@ Content Size  20 bytes
 
       let have = env.out();
       let want = "\
-Name\tfoo
-Comment\tcomment
-Created\t1970-01-01 00:00:01 UTC
-Created By\tcreated by
-Source\tsource
-Info Hash\te12253978dc6d50db11d05747abcea1ad03b51c5
-Torrent Size\t327
-Content Size\t20
-Private\tyes
-Trackers\ta\tx\ty\tz
-DHT Nodes\tx:12\t1.1.1.1:16\t[2001:db8:85a3::8a2e:370]:7334
-Piece Size\t16384
-Piece Count\t2
-File Count\t1
-Files\tfoo
+name\tfoo
+comment\tcomment
+creation date\t1970-01-01 00:00:01 UTC
+created by\tcreated by
+source\tsource
+info hash\te12253978dc6d50db11d05747abcea1ad03b51c5
+torrent size\t327
+content size\t20
+private\tyes
+trackers\ta\tx\ty\tz
+dht nodes\tx:12\t1.1.1.1:16\t[2001:db8:85a3::8a2e:370]:7334
+piece size\t16384
+piece count\t2
+file count\t1
+files\tfoo
 ";
 
       assert_eq!(have, want);
@@ -269,25 +269,25 @@ Files\tfoo
       env.run().unwrap();
 
       let have = env.out();
-      let want = "        Name  foo
-     Comment  comment
-     Created  1970-01-01 00:00:01 UTC
-  Created By  created by
-      Source  source
-   Info Hash  b9cd9cae5748518c99d00d8ae86c0162510be4d9
-Torrent Size  307 bytes
-Content Size  20 bytes
-     Private  yes
-    Trackers  b
-              c
-              a
-   DHT Nodes  x:12
-              1.1.1.1:16
-              [2001:db8:85a3::8a2e:370]:7334
-  Piece Size  16 KiB
- Piece Count  1
-  File Count  1
-       Files  foo
+      let want = "         Name  foo
+      Comment  comment
+Creation Date  1970-01-01 00:00:01 UTC
+   Created By  created by
+       Source  source
+    Info Hash  b9cd9cae5748518c99d00d8ae86c0162510be4d9
+ Torrent Size  307 bytes
+ Content Size  20 bytes
+      Private  yes
+     Trackers  b
+               c
+               a
+    DHT Nodes  x:12
+               1.1.1.1:16
+               [2001:db8:85a3::8a2e:370]:7334
+   Piece Size  16 KiB
+  Piece Count  1
+   File Count  1
+        Files  foo
 ";
 
       assert_eq!(have, want);
@@ -306,21 +306,21 @@ Content Size  20 bytes
 
       let have = env.out();
       let want = "\
-Name\tfoo
-Comment\tcomment
-Created\t1970-01-01 00:00:01 UTC
-Created By\tcreated by
-Source\tsource
-Info Hash\tb9cd9cae5748518c99d00d8ae86c0162510be4d9
-Torrent Size\t307
-Content Size\t20
-Private\tyes
-Trackers\tb\tc\ta
-DHT Nodes\tx:12\t1.1.1.1:16\t[2001:db8:85a3::8a2e:370]:7334
-Piece Size\t16384
-Piece Count\t1
-File Count\t1
-Files\tfoo
+name\tfoo
+comment\tcomment
+creation date\t1970-01-01 00:00:01 UTC
+created by\tcreated by
+source\tsource
+info hash\tb9cd9cae5748518c99d00d8ae86c0162510be4d9
+torrent size\t307
+content size\t20
+private\tyes
+trackers\tb\tc\ta
+dht nodes\tx:12\t1.1.1.1:16\t[2001:db8:85a3::8a2e:370]:7334
+piece size\t16384
+piece count\t1
+file count\t1
+files\tfoo
 ";
 
       assert_eq!(have, want);

--- a/src/table.rs
+++ b/src/table.rs
@@ -163,7 +163,7 @@ impl Table {
 
   pub(crate) fn write_tab_delimited(&self, out: &mut dyn Write) -> io::Result<()> {
     for (name, value) in self.rows() {
-      write!(out, "{}\t", name)?;
+      write!(out, "{}\t", name.to_lowercase())?;
       match value {
         Value::List(list) => {
           for (i, value) in list.iter().enumerate() {
@@ -315,7 +315,7 @@ mod tests {
         FilePath::from_components(&["d"]),
       ],
     );
-    tab_delimited(&table, "Files\tFoo/a/b\tFoo/a/c\tFoo/d\n");
+    tab_delimited(&table, "files\tFoo/a/b\tFoo/a/c\tFoo/d\n");
     human_readable(
       &table,
       "\
@@ -333,7 +333,7 @@ Files  Foo
     let mut table = Table::new();
     table.row("Foo", "bar");
     human_readable(&table, "Foo  bar\n");
-    tab_delimited(&table, "Foo\tbar\n");
+    tab_delimited(&table, "foo\tbar\n");
   }
 
   #[test]
@@ -342,7 +342,7 @@ Files  Foo
     table.row("Foo", "bar");
     table.row("X", "y");
     human_readable(&table, "Foo  bar\n  X  y\n");
-    tab_delimited(&table, "Foo\tbar\nX\ty\n");
+    tab_delimited(&table, "foo\tbar\nx\ty\n");
   }
 
   #[test]
@@ -364,8 +364,8 @@ Something  a
     tab_delimited(
       &table,
       "\
-Something\ta\tb\tc
-Other\tx\ty\tz
+something\ta\tb\tc
+other\tx\ty\tz
 ",
     );
   }
@@ -383,7 +383,7 @@ Foo  Bar: a
           y
 ",
     );
-    tab_delimited(&table, "Foo\ta\tb\tx\ty\n");
+    tab_delimited(&table, "foo\ta\tb\tx\ty\n");
   }
 
   #[test]
@@ -414,7 +414,7 @@ Second  Row:        the
     );
     tab_delimited(
       &table,
-      "First\tthe\tthing\tabout\tthat\nSecond\tthe\tthing\tabout\tthat\n",
+      "first\tthe\tthing\tabout\tthat\nsecond\tthe\tthing\tabout\tthat\n",
     );
   }
 }

--- a/src/torrent_summary.rs
+++ b/src/torrent_summary.rs
@@ -72,7 +72,7 @@ impl TorrentSummary {
     if let Some(creation_date) = self.metainfo.creation_date {
       #[allow(clippy::as_conversions)]
       table.row(
-        "Created",
+        "Creation Date",
         Utc.timestamp(
           creation_date
             .min(i64::max_value() as u64)


### PR DESCRIPTION
- Use lowercase table names when writing to terminal
- Use `Creation Date` instead of `Created`, to make it
  distinct from the `Created` field