### PR TITLE
Fail early if destination .torrent file exists

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -50,6 +50,8 @@ pub(crate) enum Error {
   NodeParsePort { text: String, source: ParseIntError },
   #[snafu(display("Failed to find opener utility, please install one of {}", tried.join(",")))]
   OpenerMissing { tried: &'static [&'static str] },
+  #[snafu(display("Output path already exists: `{}`", path.display()))]
+  OutputExists { path: PathBuf },
   #[snafu(display(
     "Interal error, this may indicate a bug in intermodal: {}\n\
      Consider filing an issue: https://github.com/casey/imdl/issues/new",

--- a/src/subcommand/torrent/create.rs
+++ b/src/subcommand/torrent/create.rs
@@ -265,6 +265,14 @@ impl Create {
         OutputTarget::File(input.parent().unwrap().join(torrent_name))
       });
 
+    if let OutputTarget::File(path) = &output {
+      if !self.force && path.exists() {
+        return Err(Error::OutputExists {
+          path: path.to_owned(),
+        });
+      }
+    }
+
     let private = if self.private { Some(true) } else { None };
 
     let creation_date = if self.no_creation_date {
@@ -1586,8 +1594,8 @@ Content Size  9 bytes
     };
     assert_matches!(
       env.run().unwrap_err(),
-      Error::Filesystem {source, path}
-      if path == env.resolve("foo.torrent") && source.kind() == io::ErrorKind::AlreadyExists
+      Error::OutputExists {path}
+      if path == env.resolve("foo.torrent")
     )
   }
 


### PR DESCRIPTION
Check if destination torrent file exists and fail early.

Creating a torrent can take a long time, so it's good if we can fail
early, instead of after a long waiting period.
