### PR TITLE
Remove `matches` macro

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -28,10 +28,6 @@ use crate::common::*;
 
 #[cfg(test)]
 #[macro_use]
-mod matches;
-
-#[cfg(test)]
-#[macro_use]
 mod assert_matches;
 
 #[macro_use]


### PR DESCRIPTION
This is now stable in Rust 1.42, but additionally, I don't
think we were actually using it.