### PR TITLE
Use imdl-indicatif

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,7 +315,7 @@ dependencies = [
  "chrono",
  "console",
  "globset",
- "indicatif",
+ "imdl-indicatif",
  "indoc",
  "lazy_static",
  "libc",
@@ -340,9 +340,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "indicatif"
+name = "imdl-indicatif"
 version = "0.14.0"
-source = "git+https://github.com/casey/indicatif.git?branch=binary-bytes-per-sec#a22e3bdce304d195890774688a1660427c59f2fd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cd52c6090487185174be0dc0c3b2ba6e8ea687422d9de66fa244e0bf9339b28"
 dependencies = [
  "console",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,7 @@ features = ["serde"]
 
 [dependencies.indicatif]
 version = "0.14.0"
-git     = "https://github.com/casey/indicatif.git"
-branch  = "binary-bytes-per-sec"
+package = "imdl-indicatif"
 
 [dependencies.serde]
 version  = "1.0.103"

--- a/src/file_status.rs
+++ b/src/file_status.rs
@@ -22,6 +22,7 @@ impl FileStatus {
     self.error.is_none()
   }
 
+  #[cfg(test)]
   pub(crate) fn is_bad(&self) -> bool {
     !self.is_good()
   }


### PR DESCRIPTION
The `0.1.0` release is coming up, and a prerequisite to publish to
crates.io is to not depend on any non crates.io dependency.

We're using the `{binary_bytes_per_sec}` formatting spec, which is only
in my fork.

I published my fork to crates.io as `imdl-indicatif`, and this diff
starts depending on that fork.

Fixes #196.