### PR TITLE
Add name and peers to links from `imdl torrent link`

### DIFF
--- a/src/subcommand/torrent/link.rs
+++ b/src/subcommand/torrent/link.rs
@@ -15,6 +15,13 @@ pub(crate) struct Link {
     parse(from_os_str)
   )]
   input: PathBuf,
+  #[structopt(
+    long = "peer",
+    short = "p",
+    value_name = "PEER",
+    help = "Add PEER to magnet link."
+  )]
+  peers: Vec<HostPort>,
 }
 
 impl Link {
@@ -25,6 +32,8 @@ impl Link {
 
     let mut link = MagnetLink::with_infohash(infohash);
 
+    link.set_name(&metainfo.info.name);
+
     let mut trackers = HashSet::new();
     for result in metainfo.trackers() {
       let tracker = result?;
@@ -32,6 +41,10 @@ impl Link {
         trackers.insert(tracker.clone());
         link.add_tracker(tracker);
       }
+    }
+
+    for peer in self.peers {
+      link.add_peer(peer);
     }
 
     outln!(env, "{}", link.to_url())?;
@@ -67,7 +80,10 @@ mod tests {
 
     let infohash = Sha1Digest::from_data(INFO.as_bytes());
 
-    assert_eq!(env.out(), format!("magnet:?xt=urn:btih:{}\n", infohash),);
+    assert_eq!(
+      env.out(),
+      format!("magnet:?xt=urn:btih:{}&dn=foo\n", infohash),
+    );
   }
 
   #[test]
@@ -96,7 +112,73 @@ mod tests {
     assert_eq!(
       env.out(),
       format!(
-        "magnet:?xt=urn:btih:{}&tr=https://foo.com/announce\n",
+        "magnet:?xt=urn:btih:{}&dn=foo&tr=https://foo.com/announce\n",
+        infohash
+      ),
+    );
+  }
+
+  #[test]
+  fn unique_trackers() {
+    let mut env = test_env! {
+      args: [
+        "torrent",
+        "link",
+        "--input",
+        "foo.torrent",
+      ],
+      tree: {
+        "foo.torrent": "d\
+          8:announce24:https://foo.com/announce\
+          13:announce-listll24:https://foo.com/announceel24:https://bar.com/announceee\
+          4:infod6:lengthi0e4:name3:foo12:piece lengthi1e6:pieces0:e\
+        e",
+      }
+    };
+
+    assert_ok!(env.run());
+
+    const INFO: &str = "d6:lengthi0e4:name3:foo12:piece lengthi1e6:pieces0:e";
+
+    let infohash = Sha1Digest::from_data(INFO.as_bytes());
+
+    assert_eq!(
+      env.out(),
+      format!(
+        "magnet:?xt=urn:btih:{}&dn=foo&tr=https://foo.com/announce&tr=https://bar.com/announce\n",
+        infohash
+      ),
+    );
+  }
+  #[test]
+  fn with_peer() {
+    let mut env = test_env! {
+      args: [
+        "torrent",
+        "link",
+        "--input",
+        "foo.torrent",
+        "--peer",
+        "foo.com:1337",
+      ],
+      tree: {
+        "foo.torrent": "d\
+          8:announce24:https://foo.com/announce\
+          4:infod6:lengthi0e4:name3:foo12:piece lengthi1e6:pieces0:e\
+        e",
+      }
+    };
+
+    assert_ok!(env.run());
+
+    const INFO: &str = "d6:lengthi0e4:name3:foo12:piece lengthi1e6:pieces0:e";
+
+    let infohash = Sha1Digest::from_data(INFO.as_bytes());
+
+    assert_eq!(
+      env.out(),
+      format!(
+        "magnet:?xt=urn:btih:{}&dn=foo&tr=https://foo.com/announce&x.pe=foo.com:1337\n",
         infohash
       ),
     );
@@ -122,7 +204,10 @@ mod tests {
 
     let infohash = Sha1Digest::from_data(INFO.as_bytes());
 
-    assert_eq!(env.out(), format!("magnet:?xt=urn:btih:{}\n", infohash),);
+    assert_eq!(
+      env.out(),
+      format!("magnet:?xt=urn:btih:{}&dn=foo\n", infohash),
+    );
   }
 
   #[test]

--- a/src/subcommand/torrent/link.rs
+++ b/src/subcommand/torrent/link.rs
@@ -19,7 +19,7 @@ pub(crate) struct Link {
     long = "peer",
     short = "p",
     value_name = "PEER",
-    help = "Add PEER to magnet link."
+    help = "Add `PEER` to magnet link."
   )]
   peers: Vec<HostPort>,
 }


### PR DESCRIPTION
Set the `dn` query parameter with `metinfo.info.name`, and allow passing
peers with:

    imdl torrent link --peer HOST:PORT