### PR TITLE
Allow reading torrent metainfo from stdin

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -61,12 +61,12 @@ pub(crate) use crate::{
   arguments::Arguments, bytes::Bytes, env::Env, error::Error, file_error::FileError,
   file_info::FileInfo, file_path::FilePath, file_status::FileStatus, files::Files, hasher::Hasher,
   host_port::HostPort, host_port_parse_error::HostPortParseError, info::Info, infohash::Infohash,
-  lint::Lint, linter::Linter, magnet_link::MagnetLink, md5_digest::Md5Digest, metainfo::Metainfo,
-  metainfo_error::MetainfoError, mode::Mode, options::Options, output_stream::OutputStream,
-  output_target::OutputTarget, piece_length_picker::PieceLengthPicker, piece_list::PieceList,
-  platform::Platform, sha1_digest::Sha1Digest, status::Status, style::Style,
-  subcommand::Subcommand, table::Table, torrent_summary::TorrentSummary, use_color::UseColor,
-  verifier::Verifier, walker::Walker,
+  input::Input, input_target::InputTarget, lint::Lint, linter::Linter, magnet_link::MagnetLink,
+  md5_digest::Md5Digest, metainfo::Metainfo, metainfo_error::MetainfoError, mode::Mode,
+  options::Options, output_stream::OutputStream, output_target::OutputTarget,
+  piece_length_picker::PieceLengthPicker, piece_list::PieceList, platform::Platform,
+  sha1_digest::Sha1Digest, status::Status, style::Style, subcommand::Subcommand, table::Table,
+  torrent_summary::TorrentSummary, use_color::UseColor, verifier::Verifier, walker::Walker,
 };
 
 // type aliases

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,21 +7,21 @@ use structopt::clap;
 pub(crate) enum Error {
   #[snafu(display("Failed to parse announce URL: {}", source))]
   AnnounceUrlParse { source: url::ParseError },
-  #[snafu(display("Failed to deserialize torrent metainfo from `{}`: {}", path.display(), source))]
+  #[snafu(display("Failed to deserialize torrent metainfo from {}: {}", input, source))]
   MetainfoDeserialize {
     source: bendy::serde::Error,
-    path: PathBuf,
+    input: InputTarget,
   },
   #[snafu(display("Failed to serialize torrent metainfo: {}", source))]
   MetainfoSerialize { source: bendy::serde::Error },
-  #[snafu(display("Failed to decode torrent metainfo from `{}`: {}", path.display(), error))]
+  #[snafu(display("Failed to decode torrent metainfo from {}: {}", input, error))]
   MetainfoDecode {
-    path: PathBuf,
+    input: InputTarget,
     error: bendy::decoding::Error,
   },
-  #[snafu(display("Metainfo from `{}` failed to validate: {}", path.display(), source))]
+  #[snafu(display("Metainfo from {} failed to validate: {}", input, source))]
   MetainfoValidate {
-    path: PathBuf,
+    input: InputTarget,
     source: MetainfoError,
   },
   #[snafu(display("Failed to parse byte count `{}`: {}", text, source))]

--- a/src/error.rs
+++ b/src/error.rs
@@ -107,6 +107,8 @@ pub(crate) enum Error {
   PrivateTrackerless,
   #[snafu(display("Failed to write to standard error: {}", source))]
   Stderr { source: io::Error },
+  #[snafu(display("Failed to read from standard input: {}", source))]
+  Stdin { source: io::Error },
   #[snafu(display("Failed to write to standard output: {}", source))]
   Stdout { source: io::Error },
   #[snafu(display(

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,0 +1,16 @@
+use crate::common::*;
+
+pub(crate) struct Input {
+  source: InputTarget,
+  data: Vec<u8>,
+}
+
+impl Input {
+  pub(crate) fn data(&self) -> &[u8] {
+    &self.data
+  }
+
+  pub(crate) fn source(&self) -> &InputTarget {
+    &self.source
+  }
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -6,11 +6,24 @@ pub(crate) struct Input {
 }
 
 impl Input {
+  pub(crate) fn new(source: InputTarget, data: Vec<u8>) -> Input {
+    Self { source, data }
+  }
+
   pub(crate) fn data(&self) -> &[u8] {
     &self.data
   }
 
   pub(crate) fn source(&self) -> &InputTarget {
     &self.source
+  }
+
+  #[cfg(test)]
+  pub(crate) fn from_path(path: &Path) -> Result<Input> {
+    let data = fs::read(path).context(error::Filesystem { path })?;
+    Ok(Input {
+      source: InputTarget::File(path.to_owned()),
+      data,
+    })
   }
 }

--- a/src/input_target.rs
+++ b/src/input_target.rs
@@ -6,28 +6,6 @@ pub(crate) enum InputTarget {
   Stdin,
 }
 
-impl InputTarget {
-  // TODO: remove
-  pub(crate) fn resolve(&self, env: &Env) -> Self {
-    match self {
-      Self::File(path) => Self::File(env.resolve(path)),
-      Self::Stdin => Self::Stdin,
-    }
-  }
-
-  // TODO: remove
-  pub(crate) fn read(&self) -> Result<Vec<u8>> {
-    match self {
-      Self::File(path) => fs::read(path).context(error::Filesystem { path }),
-      Self::Stdin => {
-        let mut buffer = Vec::new();
-        io::stdin().read_to_end(&mut buffer).context(error::Stdin)?;
-        Ok(buffer)
-      }
-    }
-  }
-}
-
 impl From<&OsStr> for InputTarget {
   fn from(text: &OsStr) -> Self {
     if text == OsStr::new("-") {
@@ -43,6 +21,16 @@ impl Display for InputTarget {
     match self {
       Self::Stdin => write!(f, "standard input"),
       Self::File(path) => write!(f, "`{}`", path.display()),
+    }
+  }
+}
+
+#[cfg(test)]
+impl<P: AsRef<Path>> PartialEq<P> for InputTarget {
+  fn eq(&self, other: &P) -> bool {
+    match self {
+      Self::File(path) => path == other.as_ref(),
+      Self::Stdin => Path::new("-") == other.as_ref(),
     }
   }
 }

--- a/src/input_target.rs
+++ b/src/input_target.rs
@@ -1,0 +1,81 @@
+use crate::common::*;
+
+#[derive(PartialEq, Debug, Clone)]
+pub(crate) enum InputTarget {
+  File(PathBuf),
+  Stdin,
+}
+
+impl InputTarget {
+  // TODO: remove
+  pub(crate) fn resolve(&self, env: &Env) -> Self {
+    match self {
+      Self::File(path) => Self::File(env.resolve(path)),
+      Self::Stdin => Self::Stdin,
+    }
+  }
+
+  // TODO: remove
+  pub(crate) fn read(&self) -> Result<Vec<u8>> {
+    match self {
+      Self::File(path) => fs::read(path).context(error::Filesystem { path }),
+      Self::Stdin => {
+        let mut buffer = Vec::new();
+        io::stdin().read_to_end(&mut buffer).context(error::Stdin)?;
+        Ok(buffer)
+      }
+    }
+  }
+}
+
+impl From<&OsStr> for InputTarget {
+  fn from(text: &OsStr) -> Self {
+    if text == OsStr::new("-") {
+      Self::Stdin
+    } else {
+      Self::File(text.into())
+    }
+  }
+}
+
+impl Display for InputTarget {
+  fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    match self {
+      Self::Stdin => write!(f, "standard input"),
+      Self::File(path) => write!(f, "`{}`", path.display()),
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn file() {
+    assert_eq!(
+      InputTarget::from(OsStr::new("foo")),
+      InputTarget::File("foo".into())
+    );
+  }
+
+  #[test]
+  fn stdio() {
+    assert_eq!(InputTarget::from(OsStr::new("-")), InputTarget::Stdin);
+  }
+
+  #[test]
+  fn display_file() {
+    let path = PathBuf::from("./path");
+    let have = InputTarget::File(path).to_string();
+    let want = "`./path`";
+    assert_eq!(have, want);
+  }
+
+  #[test]
+  fn display_stdio() {
+    let have = InputTarget::Stdin.to_string();
+    let want = "standard input";
+    assert_eq!(have, want);
+  }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,6 +64,8 @@ mod host_port;
 mod host_port_parse_error;
 mod info;
 mod infohash;
+mod input;
+mod input_target;
 mod into_u64;
 mod into_usize;
 mod lint;

--- a/src/metainfo.rs
+++ b/src/metainfo.rs
@@ -51,16 +51,14 @@ pub(crate) struct Metainfo {
 }
 
 impl Metainfo {
-  pub(crate) fn load(path: impl AsRef<Path>) -> Result<Metainfo, Error> {
-    let path = path.as_ref();
-    let bytes = fs::read(path).context(error::Filesystem { path })?;
-    Self::deserialize(path, &bytes)
+  pub(crate) fn from_input(input: &Input) -> Result<Metainfo> {
+    Self::deserialize(input.source(), input.data())
   }
 
-  pub(crate) fn deserialize(path: impl AsRef<Path>, bytes: &[u8]) -> Result<Metainfo, Error> {
-    let path = path.as_ref();
-    let metainfo =
-      bendy::serde::de::from_bytes(&bytes).context(error::MetainfoDeserialize { path })?;
+  pub(crate) fn deserialize(source: &InputTarget, data: &[u8]) -> Result<Metainfo, Error> {
+    let metainfo = bendy::serde::de::from_bytes(&data).context(error::MetainfoDeserialize {
+      input: source.clone(),
+    })?;
     Ok(metainfo)
   }
 
@@ -78,7 +76,7 @@ impl Metainfo {
 
   #[cfg(test)]
   pub(crate) fn from_bytes(bytes: &[u8]) -> Metainfo {
-    Self::deserialize("<TEST>", bytes).unwrap()
+    Self::deserialize(&InputTarget::File("<TEST>".into()), bytes).unwrap()
   }
 
   pub(crate) fn verify(&self, base: &Path, progress_bar: Option<ProgressBar>) -> Result<Status> {

--- a/src/subcommand/torrent/link.rs
+++ b/src/subcommand/torrent/link.rs
@@ -7,11 +7,13 @@ use crate::common::*;
   about("Generate a magnet link from a `.torrent` file.")
 )]
 pub(crate) struct Link {
+  // TODO: Make this an InputTarget
   #[structopt(
     long = "input",
     short = "i",
     value_name = "METAINFO",
-    help = "Generate magnet link from metainfo at `PATH`.",
+    help = "Generate magnet link from metainfo at `PATH`. If `PATH` is `-`, read metainfo from \
+            standard input.",
     parse(from_os_str)
   )]
   input: PathBuf,

--- a/src/subcommand/torrent/show.rs
+++ b/src/subcommand/torrent/show.rs
@@ -20,7 +20,7 @@ pub(crate) struct Show {
 
 impl Show {
   pub(crate) fn run(self, env: &mut Env) -> Result<(), Error> {
-    let input = env.read(self.input.clone())?;
+    let input = env.read(self.input)?;
     let summary = TorrentSummary::from_input(&input)?;
     summary.write(env)?;
     Ok(())

--- a/src/subcommand/torrent/show.rs
+++ b/src/subcommand/torrent/show.rs
@@ -11,16 +11,17 @@ pub(crate) struct Show {
     long = "input",
     short = "i",
     value_name = "PATH",
-    help = "Show information about torrent at `PATH`.",
+    help = "Show information about torrent at `PATH`. If `Path` is `-`, read torrent metainfo \
+            from standard input.",
     parse(from_os_str)
   )]
-  input: PathBuf,
+  input: InputTarget,
 }
 
 impl Show {
   pub(crate) fn run(self, env: &mut Env) -> Result<(), Error> {
-    let input = env.resolve(&self.input);
-    let summary = TorrentSummary::load(&input)?;
+    let input = env.read(self.input.clone())?;
+    let summary = TorrentSummary::from_input(&input)?;
     summary.write(env)?;
     Ok(())
   }

--- a/src/subcommand/torrent/verify/verify_step.rs
+++ b/src/subcommand/torrent/verify/verify_step.rs
@@ -2,7 +2,7 @@ use crate::common::*;
 
 #[derive(Clone, Copy)]
 pub(crate) enum VerifyStep<'a> {
-  Loading { metainfo: &'a Path },
+  Loading { metainfo: &'a InputTarget },
   Verifying { content: &'a Path },
 }
 
@@ -27,9 +27,7 @@ impl<'a> Step for VerifyStep<'a> {
 
   fn write_message(&self, write: &mut dyn Write) -> io::Result<()> {
     match self {
-      Self::Loading { metainfo } => {
-        write!(write, "Loading metainfo from `{}`…", metainfo.display())
-      }
+      Self::Loading { metainfo } => write!(write, "Loading metainfo from {}…", metainfo),
       Self::Verifying { content } => {
         write!(write, "Verifying pieces from `{}`…", content.display())
       }

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -4,6 +4,7 @@ macro_rules! test_env {
   {
     args: [$($arg:expr),* $(,)?],
     $(cwd: $cwd:expr,)?
+    $(input: $input:expr,)?
     $(err_style: $err_style:expr,)?
     tree: {
       $($tree:tt)*
@@ -15,6 +16,7 @@ macro_rules! test_env {
       TestEnvBuilder::new()
         $(.current_dir(tempdir.path().join($cwd)))?
         $(.err_style($err_style))?
+        $(.input($input))?
         .tempdir(tempdir)
         .arg("imdl")
         $(.arg($arg))*
@@ -73,8 +75,9 @@ impl TestEnv {
     fs::set_permissions(self.env.resolve(path), permissions).unwrap();
   }
 
-  pub(crate) fn load_metainfo(&self, filename: impl AsRef<Path>) -> Metainfo {
-    Metainfo::load(self.env.resolve(filename.as_ref())).unwrap()
+  pub(crate) fn load_metainfo(&mut self, filename: impl AsRef<Path>) -> Metainfo {
+    let input = self.env.read(filename.as_ref().as_os_str().into()).unwrap();
+    Metainfo::from_input(&input).unwrap()
   }
 }
 

--- a/src/torrent_summary.rs
+++ b/src/torrent_summary.rs
@@ -22,10 +22,8 @@ impl TorrentSummary {
     Ok(Self::new(metainfo, infohash, size))
   }
 
-  pub(crate) fn load(path: &Path) -> Result<Self> {
-    let bytes = fs::read(path).context(error::Filesystem { path })?;
-
-    let metainfo = Metainfo::deserialize(path, &bytes)?;
+  pub(crate) fn from_input(input: &Input) -> Result<Self> {
+    let metainfo = Metainfo::from_input(input)?;
 
     Ok(Self::from_metainfo(metainfo)?)
   }


### PR DESCRIPTION
Torrent metainfo can be read from standard input by passing `-`:

    cat a.torrent | imdl torrent verify --input -
    cat a.torrent | imdl torrent link --input -
    cat a.torrent | imdl torrent show --input -

Fixes #256.