### PR TITLE
Fix build errors

### DIFF
--- a/bin/package
+++ b/bin/package
@@ -15,6 +15,10 @@ test -f Cargo.lock || cargo generate-lockfile
 
 echo "Building $bin..."
 
+if [ "$os" = "ubuntu-latest" ]; then
+  sudo apt-get install musl-tools
+fi
+
 case $os in
   ubuntu-latest | macos-latest)
     cargo rustc --bin $bin --target $target --release -- -C lto
@@ -33,7 +37,7 @@ cp \
   Cargo.lock \
   Cargo.toml \
   CHANGELOG.md \
-  CONTRIBUTING.md \
+  CONTRIBUTING \
   LICENSE \
   README.md \
   $dist


### PR DESCRIPTION
- Install `musl-tools` which provides the `musl-gcc` binary, needed for
  the package script on ubuntu.
- Fix contributing file name