### PR TITLE
Add shell completion scripts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,6 +62,11 @@ jobs:
         components: rustfmt
     - name: Format
       run: cargo +nightly fmt --all -- --check
+    - name: Completion Scripts
+      if: matrix.os != 'windows-latest'
+      run: |
+        ./bin/generate-completions
+        git diff --no-ext-diff --quiet --exit-code
     - name: Readme
       if: matrix.os != 'windows-latest'
       run: |

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ For more about the project and its goals, check out [this post](https://rodarmor
     - [Supported Operating Systems](#supported-operating-systems)
     - [Pre-built binaries](#pre-built-binaries)
     - [Cargo](#cargo)
+  - [Shell Completion Scripts](#shell-completion-scripts)
   - [Semantic Versioning](#semantic-versioning)
   - [Unstable Features](#unstable-features)
 - [Acknowledgments](#acknowledgments)
@@ -49,6 +50,19 @@ curl --proto '=https' --tlsv1.2 -sSf https://imdl.io/install.sh | bash -s -- --t
 `imdl` is written in [Rust](https://www.rust-lang.org/) and can be built from
 source and installed with `cargo install imdl`. To get Rust, use the
 [rustup installer](https://rustup.rs/).
+
+### Shell Completion Scripts
+
+Shell completion scripts for Bash, Zsh, Fish, PowerShell, and Elvish are
+available in the [completions](completions directory). Please refer to your
+shell's documentation for how to install them.
+
+The `imdl` binary can also generate the same completion scripts at runtime,
+using the `completions` command:
+
+```sh
+$ imdl completions --shell bash > imdl.bash
+```
 
 ### Semantic Versioning
 

--- a/bin/generate-completions
+++ b/bin/generate-completions
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+for script in completions/*; do
+  shell=${script##*.}
+  cargo run -- completions --shell $shell > $script
+done

--- a/bin/package
+++ b/bin/package
@@ -32,14 +32,15 @@ esac
 
 echo "Copying release files..."
 mkdir dist
-cp \
+cp -r \
   $executable \
-  Cargo.lock \
-  Cargo.toml \
   CHANGELOG.md \
   CONTRIBUTING \
+  Cargo.lock \
+  Cargo.toml \
   LICENSE \
   README.md \
+  completions \
   $dist
 
 cd $dist

--- a/completions/imdl.bash
+++ b/completions/imdl.bash
@@ -1,0 +1,404 @@
+_imdl() {
+    local i cur prev opts cmds
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    cmd=""
+    opts=""
+
+    for i in ${COMP_WORDS[@]}
+    do
+        case "${i}" in
+            imdl)
+                cmd="imdl"
+                ;;
+            
+            completions)
+                cmd+="__completions"
+                ;;
+            create)
+                cmd+="__create"
+                ;;
+            help)
+                cmd+="__help"
+                ;;
+            link)
+                cmd+="__link"
+                ;;
+            piece-length)
+                cmd+="__piece__length"
+                ;;
+            piece-size)
+                cmd+="__piece__size"
+                ;;
+            show)
+                cmd+="__show"
+                ;;
+            stats)
+                cmd+="__stats"
+                ;;
+            torrent)
+                cmd+="__torrent"
+                ;;
+            verify)
+                cmd+="__verify"
+                ;;
+            *)
+                ;;
+        esac
+    done
+
+    case "${cmd}" in
+        imdl)
+            opts=" -u -h -V  --unstable --help --version --color   torrent completions help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                
+                --color)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        
+        imdl__completions)
+            opts=" -h -V -s  --help --version --shell  "
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                
+                --shell)
+                    COMPREPLY=($(compgen -W "zsh bash fish powershell elvish" -- "${cur}"))
+                    return 0
+                    ;;
+                    -s)
+                    COMPREPLY=($(compgen -W "zsh bash fish powershell elvish" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        imdl__help)
+            opts=" -h -V  --help --version  "
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        imdl__torrent)
+            opts=" -h -V  --help --version   create link piece-length show stats verify help  piece-size"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        imdl__torrent__create)
+            opts=" -n -F -f -h -j -M -O -P -S -V -a -A -t -c -g -i -N -o -p -s  --dry-run --follow-symlinks --force --include-hidden --include-junk --link --md5 --no-created-by --no-creation-date --open --private --show --help --version --announce --allow --announce-tier --comment --node --glob --input --name --sort-by --output --peer --piece-length --source  "
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                
+                --announce)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                    -a)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --allow)
+                    COMPREPLY=($(compgen -W "private-trackerless small-piece-length uneven-piece-length" -- "${cur}"))
+                    return 0
+                    ;;
+                    -A)
+                    COMPREPLY=($(compgen -W "private-trackerless small-piece-length uneven-piece-length" -- "${cur}"))
+                    return 0
+                    ;;
+                --announce-tier)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                    -t)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --comment)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                    -c)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --node)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --glob)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                    -g)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --input)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                    -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --name)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                    -N)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --sort-by)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --output)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                    -o)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --peer)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --piece-length)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                    -p)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --source)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                    -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        imdl__torrent__help)
+            opts=" -h -V  --help --version  "
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        imdl__torrent__link)
+            opts=" -O -h -V -i -p  --open --help --version --input --peer  "
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                
+                --input)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                    -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --peer)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                    -p)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        imdl__torrent__piece__length)
+            opts=" -h -V  --help --version  "
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        imdl__torrent__piece__size)
+            opts=" -h -V  --help --version  "
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        imdl__torrent__show)
+            opts=" -h -V -i  --help --version --input  "
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                
+                --input)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                    -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        imdl__torrent__stats)
+            opts=" -p -h -V -l -e -i  --print --help --version --limit --extract-pattern --input  "
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                
+                --limit)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                    -l)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --extract-pattern)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                    -e)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --input)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                    -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        imdl__torrent__verify)
+            opts=" -h -V -i -c  --help --version --input --content  "
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                
+                --input)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                    -i)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --content)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                    -c)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+    esac
+}
+
+complete -F _imdl -o bashdefault -o default imdl

--- a/completions/imdl.elvish
+++ b/completions/imdl.elvish
@@ -1,0 +1,194 @@
+edit:completion:arg-completer[imdl] = [@words]{
+    fn spaces [n]{
+        repeat $n ' ' | joins ''
+    }
+    fn cand [text desc]{
+        edit:complex-candidate $text &display-suffix=' '(spaces (- 14 (wcswidth $text)))$desc
+    }
+    command = 'imdl'
+    for word $words[1:-1] {
+        if (has-prefix $word '-') {
+            break
+        }
+        command = $command';'$word
+    }
+    completions = [
+        &'imdl'= {
+            cand --color 'Print colorful output according to `WHEN`. When `auto`, the default, colored output is only enabled if imdl detects that it is connected to a terminal, the `NO_COLOR` environment variable is not set, and the `TERM` environment variable is not set to `dumb`.'
+            cand -u 'Enable unstable features. To avoid premature stabilization and excessive version churn, unstable features are unavailable unless this flag is set. Unstable features are not bound by semantic versioning stability guarantees, and may be changed or removed at any time.'
+            cand --unstable 'Enable unstable features. To avoid premature stabilization and excessive version churn, unstable features are unavailable unless this flag is set. Unstable features are not bound by semantic versioning stability guarantees, and may be changed or removed at any time.'
+            cand -h 'Print help message.'
+            cand --help 'Print help message.'
+            cand -V 'Print version number.'
+            cand --version 'Print version number.'
+            cand torrent 'Subcommands related to the BitTorrent protocol.'
+            cand completions 'Print shell completion scripts to standard output.'
+            cand help 'Prints this message or the help of the given subcommand(s)'
+        }
+        &'imdl;torrent'= {
+            cand -h 'Print help message.'
+            cand --help 'Print help message.'
+            cand -V 'Print version number.'
+            cand --version 'Print version number.'
+            cand create 'Create a `.torrent` file.'
+            cand link 'Generate a magnet link from a `.torrent` file.'
+            cand piece-length 'Display information about automatic piece length selection.'
+            cand show 'Display information about a `.torrent` file.'
+            cand stats 'Show statistics about a collection of `.torrent` files.'
+            cand verify 'Verify files against a `.torrent` file.'
+            cand help 'Prints this message or the help of the given subcommand(s)'
+        }
+        &'imdl;torrent;create'= {
+            cand -a 'Use `URL` as the primary tracker announce URL. To supply multiple announce URLs, also use `--announce-tier`.'
+            cand --announce 'Use `URL` as the primary tracker announce URL. To supply multiple announce URLs, also use `--announce-tier`.'
+            cand -A 'Allow `LINT`. Lints check for conditions which, although permitted, are not usually desirable. For example, piece length can be any non-zero value, but probably shouldn''t be below 16 KiB. The lint `small-piece-size` checks for this, and `--allow small-piece-size` can be used to disable this check.'
+            cand --allow 'Allow `LINT`. Lints check for conditions which, although permitted, are not usually desirable. For example, piece length can be any non-zero value, but probably shouldn''t be below 16 KiB. The lint `small-piece-size` checks for this, and `--allow small-piece-size` can be used to disable this check.'
+            cand -t 'Use `URL-LIST` as a tracker announce tier. Each instance adds a new tier. To add multiple trackers to a given tier, separate their announce URLs with commas:
+
+`--announce-tier udp://example.com:80/announce,https://example.net:443/announce`
+            
+Announce tiers are stored in the `announce-list` key of the top-level metainfo dictionary as a list of lists of strings, as defined by BEP 12: Multitracker Metadata Extension.
+            
+Note: Many BitTorrent clients do not implement the behavior described in BEP 12. See the discussion here for more details: https://github.com/bittorrent/bittorrent.org/issues/82'
+            cand --announce-tier 'Use `URL-LIST` as a tracker announce tier. Each instance adds a new tier. To add multiple trackers to a given tier, separate their announce URLs with commas:
+
+`--announce-tier udp://example.com:80/announce,https://example.net:443/announce`
+            
+Announce tiers are stored in the `announce-list` key of the top-level metainfo dictionary as a list of lists of strings, as defined by BEP 12: Multitracker Metadata Extension.
+            
+Note: Many BitTorrent clients do not implement the behavior described in BEP 12. See the discussion here for more details: https://github.com/bittorrent/bittorrent.org/issues/82'
+            cand -c 'Include `TEXT` as the comment for generated `.torrent` file. Stored under `comment` key of top-level metainfo dictionary.'
+            cand --comment 'Include `TEXT` as the comment for generated `.torrent` file. Stored under `comment` key of top-level metainfo dictionary.'
+            cand --node 'Add DHT bootstrap node `NODE` to torrent. `NODE` should be in the form `HOST:PORT`, where `HOST` is a domain name, an IPv4 address, or an IPv6 address surrounded by brackets. May be given more than once to add multiple bootstrap nodes.
+
+Examples:
+
+    --node router.example.com:1337
+
+    --node 203.0.113.0:2290
+
+    --node [2001:db8:4275:7920:6269:7463:6f69:6e21]:8832'
+            cand -g 'Include or exclude files that match `GLOB`. Multiple glob may be provided, with the last one taking precedence. Precede a glob with `!` to exclude it.'
+            cand --glob 'Include or exclude files that match `GLOB`. Multiple glob may be provided, with the last one taking precedence. Precede a glob with `!` to exclude it.'
+            cand -i 'Read torrent contents from `PATH`. If `PATH` is a file, torrent will be a single-file torrent, if `PATH` is a directory, torrent will be a multi-file torrent.'
+            cand --input 'Read torrent contents from `PATH`. If `PATH` is a file, torrent will be a single-file torrent, if `PATH` is a directory, torrent will be a multi-file torrent.'
+            cand -N 'Set name of torrent to `TEXT`. Defaults to the filename of the argument to `--input`.'
+            cand --name 'Set name of torrent to `TEXT`. Defaults to the filename of the argument to `--input`.'
+            cand --sort-by 'Set the order of files within a torrent. `SPEC` should be of the form `KEY:ORDER`, with `KEY` being one of `path` or `size`, and `ORDER` being `ascending` or `descending`. `:ORDER` defaults to `ascending` if omitted. The `--sort-by` flag may be given more than once, with later values being used to break ties. Ties that remain are broken in ascending path order.
+
+Sort in ascending order by path, the default:
+
+    --sort-by path:ascending
+
+Sort in ascending order by path, more concisely:
+
+    --sort-by path
+
+Sort in ascending order by size, break ties in descending path order:
+
+    --sort-by size:ascending --sort-by path:descending'
+            cand -o 'Save `.torrent` file to `TARGET`, or print to standard output if `TARGET` is `-`. Defaults to `$INPUT.torrent`.'
+            cand --output 'Save `.torrent` file to `TARGET`, or print to standard output if `TARGET` is `-`. Defaults to `$INPUT.torrent`.'
+            cand --peer 'Add `PEER` to magnet link.'
+            cand -p 'Set piece length to `BYTES`. Accepts SI units, e.g. kib, mib, and gib.'
+            cand --piece-length 'Set piece length to `BYTES`. Accepts SI units, e.g. kib, mib, and gib.'
+            cand -s 'Set torrent source to `TEXT`. Stored under `source` key of info dictionary. This is useful for keeping statistics from being mis-reported when participating in swarms with the same contents, but with different trackers. When source is set to a unique value for torrents with the same contents, torrent clients will treat them as distinct torrents, and not share peers between them, and will correctly report download and upload statistics to multiple trackers.'
+            cand --source 'Set torrent source to `TEXT`. Stored under `source` key of info dictionary. This is useful for keeping statistics from being mis-reported when participating in swarms with the same contents, but with different trackers. When source is set to a unique value for torrents with the same contents, torrent clients will treat them as distinct torrents, and not share peers between them, and will correctly report download and upload statistics to multiple trackers.'
+            cand -n 'Skip writing `.torrent` file to disk.'
+            cand --dry-run 'Skip writing `.torrent` file to disk.'
+            cand -F 'Follow symlinks in torrent input. By default, symlinks to files and directories are not included in torrent contents.'
+            cand --follow-symlinks 'Follow symlinks in torrent input. By default, symlinks to files and directories are not included in torrent contents.'
+            cand -f 'Overwrite the destination `.torrent` file, if it exists.'
+            cand --force 'Overwrite the destination `.torrent` file, if it exists.'
+            cand -h 'Include hidden files that would otherwise be skipped, such as files that start with a `.`, and files hidden by file attributes on macOS and Windows.'
+            cand --include-hidden 'Include hidden files that would otherwise be skipped, such as files that start with a `.`, and files hidden by file attributes on macOS and Windows.'
+            cand -j 'Include junk files that would otherwise be skipped.'
+            cand --include-junk 'Include junk files that would otherwise be skipped.'
+            cand --link 'Print created torrent `magnet:` URL to standard output'
+            cand -M 'Include MD5 checksum of each file in the torrent. N.B. MD5 is cryptographically broken and only suitable for checking for accidental corruption.'
+            cand --md5 'Include MD5 checksum of each file in the torrent. N.B. MD5 is cryptographically broken and only suitable for checking for accidental corruption.'
+            cand --no-created-by 'Do not populate `created by` key of generated torrent with imdl version information.'
+            cand --no-creation-date 'Do not populate `creation date` key of generated torrent with current time.'
+            cand -O 'Open `.torrent` file after creation. Uses `xdg-open`, `gnome-open`, or `kde-open` on Linux; `open` on macOS; and `cmd /C start` on Windows'
+            cand --open 'Open `.torrent` file after creation. Uses `xdg-open`, `gnome-open`, or `kde-open` on Linux; `open` on macOS; and `cmd /C start` on Windows'
+            cand -P 'Set the `private` flag. Torrent clients that understand the flag and participate in the swarm of a torrent with the flag set will only announce themselves to the announce URLs included in the torrent, and will not use other peer discovery mechanisms, such as the DHT or local peer discovery. See BEP 27: Private Torrents for more information.'
+            cand --private 'Set the `private` flag. Torrent clients that understand the flag and participate in the swarm of a torrent with the flag set will only announce themselves to the announce URLs included in the torrent, and will not use other peer discovery mechanisms, such as the DHT or local peer discovery. See BEP 27: Private Torrents for more information.'
+            cand -S 'Display information about created torrent file.'
+            cand --show 'Display information about created torrent file.'
+            cand --help 'Print help message.'
+            cand -V 'Print version number.'
+            cand --version 'Print version number.'
+        }
+        &'imdl;torrent;link'= {
+            cand -i 'Generate magnet link from metainfo at `PATH`. If `PATH` is `-`, read metainfo from standard input.'
+            cand --input 'Generate magnet link from metainfo at `PATH`. If `PATH` is `-`, read metainfo from standard input.'
+            cand -p 'Add `PEER` to magnet link.'
+            cand --peer 'Add `PEER` to magnet link.'
+            cand -O 'Open generated magnet link. Uses `xdg-open`, `gnome-open`, or `kde-open` on Linux; `open` on macOS; and `cmd /C start` on Windows'
+            cand --open 'Open generated magnet link. Uses `xdg-open`, `gnome-open`, or `kde-open` on Linux; `open` on macOS; and `cmd /C start` on Windows'
+            cand -h 'Print help message.'
+            cand --help 'Print help message.'
+            cand -V 'Print version number.'
+            cand --version 'Print version number.'
+        }
+        &'imdl;torrent;piece-length'= {
+            cand -h 'Print help message.'
+            cand --help 'Print help message.'
+            cand -V 'Print version number.'
+            cand --version 'Print version number.'
+        }
+        &'imdl;torrent;show'= {
+            cand -i 'Show information about torrent at `PATH`. If `Path` is `-`, read torrent metainfo from standard input.'
+            cand --input 'Show information about torrent at `PATH`. If `Path` is `-`, read torrent metainfo from standard input.'
+            cand -h 'Print help message.'
+            cand --help 'Print help message.'
+            cand -V 'Print version number.'
+            cand --version 'Print version number.'
+        }
+        &'imdl;torrent;stats'= {
+            cand -l 'Stop after processing `N` torrents. Useful when processing large collections of `.torrent` files.'
+            cand --limit 'Stop after processing `N` torrents. Useful when processing large collections of `.torrent` files.'
+            cand -e 'Extract and display values under key paths that match `REGEX`. Subkeys of a bencodeded dictionary are delimited by `/`, and values of a bencoded list are delmited by `*`. For example, given the following bencoded dictionary `{"foo": [{"bar": {"baz": 2}}]}`, the value `2`''s key path will be `foo*bar/baz`. The value `2` would be displayed if any of `bar`, `foo[*]bar/baz`, or `foo.*baz` were passed to `--extract-pattern.'
+            cand --extract-pattern 'Extract and display values under key paths that match `REGEX`. Subkeys of a bencodeded dictionary are delimited by `/`, and values of a bencoded list are delmited by `*`. For example, given the following bencoded dictionary `{"foo": [{"bar": {"baz": 2}}]}`, the value `2`''s key path will be `foo*bar/baz`. The value `2` would be displayed if any of `bar`, `foo[*]bar/baz`, or `foo.*baz` were passed to `--extract-pattern.'
+            cand -i 'Search `PATH` for torrents. May be a directory or a single torrent file.'
+            cand --input 'Search `PATH` for torrents. May be a directory or a single torrent file.'
+            cand -p 'Pretty print the contents of each torrent as it is processed.'
+            cand --print 'Pretty print the contents of each torrent as it is processed.'
+            cand -h 'Print help message.'
+            cand --help 'Print help message.'
+            cand -V 'Print version number.'
+            cand --version 'Print version number.'
+        }
+        &'imdl;torrent;verify'= {
+            cand -i 'Verify torrent contents against torrent metainfo in `METAINFO`. If `METAINFO` is `-`, read metainfo from standard input.'
+            cand --input 'Verify torrent contents against torrent metainfo in `METAINFO`. If `METAINFO` is `-`, read metainfo from standard input.'
+            cand -c 'Verify torrent content at `PATH` against torrent metainfo. Defaults to `name` field of torrent info dictionary.'
+            cand --content 'Verify torrent content at `PATH` against torrent metainfo. Defaults to `name` field of torrent info dictionary.'
+            cand -h 'Print help message.'
+            cand --help 'Print help message.'
+            cand -V 'Print version number.'
+            cand --version 'Print version number.'
+        }
+        &'imdl;torrent;help'= {
+            cand -h 'Prints help information'
+            cand --help 'Prints help information'
+            cand -V 'Prints version information'
+            cand --version 'Prints version information'
+        }
+        &'imdl;completions'= {
+            cand -s 'Print completions for `SHELL`.'
+            cand --shell 'Print completions for `SHELL`.'
+            cand -h 'Print help message.'
+            cand --help 'Print help message.'
+            cand -V 'Print version number.'
+            cand --version 'Print version number.'
+        }
+        &'imdl;help'= {
+            cand -h 'Prints help information'
+            cand --help 'Prints help information'
+            cand -V 'Prints version information'
+            cand --version 'Prints version information'
+        }
+    ]
+    $completions[$command]
+}

--- a/completions/imdl.fish
+++ b/completions/imdl.fish
@@ -1,74 +1,30 @@
-#compdef imdl
-
-autoload -U is-at-least
-
-_imdl() {
-    typeset -A opt_args
-    typeset -a _arguments_options
-    local ret=1
-
-    if is-at-least 5.2; then
-        _arguments_options=(-s -S -C)
-    else
-        _arguments_options=(-s -C)
-    fi
-
-    local context curcontext="$curcontext" state line
-    _arguments "${_arguments_options[@]}" \
-'--color=[Print colorful output according to `WHEN`. When `auto`, the default, colored output is only enabled if imdl detects that it is connected to a terminal, the `NO_COLOR` environment variable is not set, and the `TERM` environment variable is not set to `dumb`.]: :(auto always never)' \
-'-u[Enable unstable features. To avoid premature stabilization and excessive version churn, unstable features are unavailable unless this flag is set. Unstable features are not bound by semantic versioning stability guarantees, and may be changed or removed at any time.]' \
-'--unstable[Enable unstable features. To avoid premature stabilization and excessive version churn, unstable features are unavailable unless this flag is set. Unstable features are not bound by semantic versioning stability guarantees, and may be changed or removed at any time.]' \
-'-h[Print help message.]' \
-'--help[Print help message.]' \
-'-V[Print version number.]' \
-'--version[Print version number.]' \
-":: :_imdl_commands" \
-"*::: :->imdl" \
-&& ret=0
-    case $state in
-    (imdl)
-        words=($line[1] "${words[@]}")
-        (( CURRENT += 1 ))
-        curcontext="${curcontext%:*:*}:imdl-command-$line[1]:"
-        case $line[1] in
-            (torrent)
-_arguments "${_arguments_options[@]}" \
-'-h[Print help message.]' \
-'--help[Print help message.]' \
-'-V[Print version number.]' \
-'--version[Print version number.]' \
-":: :_imdl__torrent_commands" \
-"*::: :->torrent" \
-&& ret=0
-case $state in
-    (torrent)
-        words=($line[1] "${words[@]}")
-        (( CURRENT += 1 ))
-        curcontext="${curcontext%:*:*}:imdl-torrent-command-$line[1]:"
-        case $line[1] in
-            (create)
-_arguments "${_arguments_options[@]}" \
-'-a+[Use `URL` as the primary tracker announce URL. To supply multiple announce URLs, also use `--announce-tier`.]' \
-'--announce=[Use `URL` as the primary tracker announce URL. To supply multiple announce URLs, also use `--announce-tier`.]' \
-'*-A+[Allow `LINT`. Lints check for conditions which, although permitted, are not usually desirable. For example, piece length can be any non-zero value, but probably shouldn'\''t be below 16 KiB. The lint `small-piece-size` checks for this, and `--allow small-piece-size` can be used to disable this check.]: :(private-trackerless small-piece-length uneven-piece-length)' \
-'*--allow=[Allow `LINT`. Lints check for conditions which, although permitted, are not usually desirable. For example, piece length can be any non-zero value, but probably shouldn'\''t be below 16 KiB. The lint `small-piece-size` checks for this, and `--allow small-piece-size` can be used to disable this check.]: :(private-trackerless small-piece-length uneven-piece-length)' \
-'*-t+[Use `URL-LIST` as a tracker announce tier. Each instance adds a new tier. To add multiple trackers to a given tier, separate their announce URLs with commas:
+complete -c imdl -n "__fish_use_subcommand" -l color -d 'Print colorful output according to `WHEN`. When `auto`, the default, colored output is only enabled if imdl detects that it is connected to a terminal, the `NO_COLOR` environment variable is not set, and the `TERM` environment variable is not set to `dumb`.' -r -f -a "auto always never"
+complete -c imdl -n "__fish_use_subcommand" -s u -l unstable -d 'Enable unstable features. To avoid premature stabilization and excessive version churn, unstable features are unavailable unless this flag is set. Unstable features are not bound by semantic versioning stability guarantees, and may be changed or removed at any time.'
+complete -c imdl -n "__fish_use_subcommand" -s h -l help -d 'Print help message.'
+complete -c imdl -n "__fish_use_subcommand" -s V -l version -d 'Print version number.'
+complete -c imdl -n "__fish_use_subcommand" -f -a "torrent" -d 'Subcommands related to the BitTorrent protocol.'
+complete -c imdl -n "__fish_use_subcommand" -f -a "completions" -d 'Print shell completion scripts to standard output.'
+complete -c imdl -n "__fish_use_subcommand" -f -a "help" -d 'Prints this message or the help of the given subcommand(s)'
+complete -c imdl -n "__fish_seen_subcommand_from torrent" -s h -l help -d 'Print help message.'
+complete -c imdl -n "__fish_seen_subcommand_from torrent" -s V -l version -d 'Print version number.'
+complete -c imdl -n "__fish_seen_subcommand_from torrent" -f -a "create" -d 'Create a `.torrent` file.'
+complete -c imdl -n "__fish_seen_subcommand_from torrent" -f -a "link" -d 'Generate a magnet link from a `.torrent` file.'
+complete -c imdl -n "__fish_seen_subcommand_from torrent" -f -a "piece-length" -d 'Display information about automatic piece length selection.'
+complete -c imdl -n "__fish_seen_subcommand_from torrent" -f -a "show" -d 'Display information about a `.torrent` file.'
+complete -c imdl -n "__fish_seen_subcommand_from torrent" -f -a "stats" -d 'Show statistics about a collection of `.torrent` files.'
+complete -c imdl -n "__fish_seen_subcommand_from torrent" -f -a "verify" -d 'Verify files against a `.torrent` file.'
+complete -c imdl -n "__fish_seen_subcommand_from torrent" -f -a "help" -d 'Prints this message or the help of the given subcommand(s)'
+complete -c imdl -n "__fish_seen_subcommand_from create" -s a -l announce -d 'Use `URL` as the primary tracker announce URL. To supply multiple announce URLs, also use `--announce-tier`.'
+complete -c imdl -n "__fish_seen_subcommand_from create" -s A -l allow -d 'Allow `LINT`. Lints check for conditions which, although permitted, are not usually desirable. For example, piece length can be any non-zero value, but probably shouldn\'t be below 16 KiB. The lint `small-piece-size` checks for this, and `--allow small-piece-size` can be used to disable this check.' -r -f -a "private-trackerless small-piece-length uneven-piece-length"
+complete -c imdl -n "__fish_seen_subcommand_from create" -s t -l announce-tier -d 'Use `URL-LIST` as a tracker announce tier. Each instance adds a new tier. To add multiple trackers to a given tier, separate their announce URLs with commas:
 
 `--announce-tier udp://example.com:80/announce,https://example.net:443/announce`
             
 Announce tiers are stored in the `announce-list` key of the top-level metainfo dictionary as a list of lists of strings, as defined by BEP 12: Multitracker Metadata Extension.
             
-Note: Many BitTorrent clients do not implement the behavior described in BEP 12. See the discussion here for more details: https://github.com/bittorrent/bittorrent.org/issues/82]' \
-'*--announce-tier=[Use `URL-LIST` as a tracker announce tier. Each instance adds a new tier. To add multiple trackers to a given tier, separate their announce URLs with commas:
-
-`--announce-tier udp://example.com:80/announce,https://example.net:443/announce`
-            
-Announce tiers are stored in the `announce-list` key of the top-level metainfo dictionary as a list of lists of strings, as defined by BEP 12: Multitracker Metadata Extension.
-            
-Note: Many BitTorrent clients do not implement the behavior described in BEP 12. See the discussion here for more details: https://github.com/bittorrent/bittorrent.org/issues/82]' \
-'-c+[Include `TEXT` as the comment for generated `.torrent` file. Stored under `comment` key of top-level metainfo dictionary.]' \
-'--comment=[Include `TEXT` as the comment for generated `.torrent` file. Stored under `comment` key of top-level metainfo dictionary.]' \
-'*--node=[Add DHT bootstrap node `NODE` to torrent. `NODE` should be in the form `HOST:PORT`, where `HOST` is a domain name, an IPv4 address, or an IPv6 address surrounded by brackets. May be given more than once to add multiple bootstrap nodes.
+Note: Many BitTorrent clients do not implement the behavior described in BEP 12. See the discussion here for more details: https://github.com/bittorrent/bittorrent.org/issues/82'
+complete -c imdl -n "__fish_seen_subcommand_from create" -s c -l comment -d 'Include `TEXT` as the comment for generated `.torrent` file. Stored under `comment` key of top-level metainfo dictionary.'
+complete -c imdl -n "__fish_seen_subcommand_from create" -l node -d 'Add DHT bootstrap node `NODE` to torrent. `NODE` should be in the form `HOST:PORT`, where `HOST` is a domain name, an IPv4 address, or an IPv6 address surrounded by brackets. May be given more than once to add multiple bootstrap nodes.
 
 Examples:
 
@@ -76,14 +32,11 @@ Examples:
 
     --node 203.0.113.0:2290
 
-    --node \[2001:db8:4275:7920:6269:7463:6f69:6e21\]:8832]' \
-'*-g+[Include or exclude files that match `GLOB`. Multiple glob may be provided, with the last one taking precedence. Precede a glob with `!` to exclude it.]' \
-'*--glob=[Include or exclude files that match `GLOB`. Multiple glob may be provided, with the last one taking precedence. Precede a glob with `!` to exclude it.]' \
-'-i+[Read torrent contents from `PATH`. If `PATH` is a file, torrent will be a single-file torrent, if `PATH` is a directory, torrent will be a multi-file torrent.]' \
-'--input=[Read torrent contents from `PATH`. If `PATH` is a file, torrent will be a single-file torrent, if `PATH` is a directory, torrent will be a multi-file torrent.]' \
-'-N+[Set name of torrent to `TEXT`. Defaults to the filename of the argument to `--input`.]' \
-'--name=[Set name of torrent to `TEXT`. Defaults to the filename of the argument to `--input`.]' \
-'*--sort-by=[Set the order of files within a torrent. `SPEC` should be of the form `KEY:ORDER`, with `KEY` being one of `path` or `size`, and `ORDER` being `ascending` or `descending`. `:ORDER` defaults to `ascending` if omitted. The `--sort-by` flag may be given more than once, with later values being used to break ties. Ties that remain are broken in ascending path order.
+    --node [2001:db8:4275:7920:6269:7463:6f69:6e21]:8832'
+complete -c imdl -n "__fish_seen_subcommand_from create" -s g -l glob -d 'Include or exclude files that match `GLOB`. Multiple glob may be provided, with the last one taking precedence. Precede a glob with `!` to exclude it.'
+complete -c imdl -n "__fish_seen_subcommand_from create" -s i -l input -d 'Read torrent contents from `PATH`. If `PATH` is a file, torrent will be a single-file torrent, if `PATH` is a directory, torrent will be a multi-file torrent.'
+complete -c imdl -n "__fish_seen_subcommand_from create" -s N -l name -d 'Set name of torrent to `TEXT`. Defaults to the filename of the argument to `--input`.'
+complete -c imdl -n "__fish_seen_subcommand_from create" -l sort-by -d 'Set the order of files within a torrent. `SPEC` should be of the form `KEY:ORDER`, with `KEY` being one of `path` or `size`, and `ORDER` being `ascending` or `descending`. `:ORDER` defaults to `ascending` if omitted. The `--sort-by` flag may be given more than once, with later values being used to break ties. Ties that remain are broken in ascending path order.
 
 Sort in ascending order by path, the default:
 
@@ -95,241 +48,49 @@ Sort in ascending order by path, more concisely:
 
 Sort in ascending order by size, break ties in descending path order:
 
-    --sort-by size:ascending --sort-by path:descending]' \
-'-o+[Save `.torrent` file to `TARGET`, or print to standard output if `TARGET` is `-`. Defaults to `$INPUT.torrent`.]' \
-'--output=[Save `.torrent` file to `TARGET`, or print to standard output if `TARGET` is `-`. Defaults to `$INPUT.torrent`.]' \
-'*--peer=[Add `PEER` to magnet link.]' \
-'-p+[Set piece length to `BYTES`. Accepts SI units, e.g. kib, mib, and gib.]' \
-'--piece-length=[Set piece length to `BYTES`. Accepts SI units, e.g. kib, mib, and gib.]' \
-'-s+[Set torrent source to `TEXT`. Stored under `source` key of info dictionary. This is useful for keeping statistics from being mis-reported when participating in swarms with the same contents, but with different trackers. When source is set to a unique value for torrents with the same contents, torrent clients will treat them as distinct torrents, and not share peers between them, and will correctly report download and upload statistics to multiple trackers.]' \
-'--source=[Set torrent source to `TEXT`. Stored under `source` key of info dictionary. This is useful for keeping statistics from being mis-reported when participating in swarms with the same contents, but with different trackers. When source is set to a unique value for torrents with the same contents, torrent clients will treat them as distinct torrents, and not share peers between them, and will correctly report download and upload statistics to multiple trackers.]' \
-'-n[Skip writing `.torrent` file to disk.]' \
-'--dry-run[Skip writing `.torrent` file to disk.]' \
-'-F[Follow symlinks in torrent input. By default, symlinks to files and directories are not included in torrent contents.]' \
-'--follow-symlinks[Follow symlinks in torrent input. By default, symlinks to files and directories are not included in torrent contents.]' \
-'-f[Overwrite the destination `.torrent` file, if it exists.]' \
-'--force[Overwrite the destination `.torrent` file, if it exists.]' \
-'-h[Include hidden files that would otherwise be skipped, such as files that start with a `.`, and files hidden by file attributes on macOS and Windows.]' \
-'--include-hidden[Include hidden files that would otherwise be skipped, such as files that start with a `.`, and files hidden by file attributes on macOS and Windows.]' \
-'-j[Include junk files that would otherwise be skipped.]' \
-'--include-junk[Include junk files that would otherwise be skipped.]' \
-'--link[Print created torrent `magnet:` URL to standard output]' \
-'-M[Include MD5 checksum of each file in the torrent. N.B. MD5 is cryptographically broken and only suitable for checking for accidental corruption.]' \
-'--md5[Include MD5 checksum of each file in the torrent. N.B. MD5 is cryptographically broken and only suitable for checking for accidental corruption.]' \
-'--no-created-by[Do not populate `created by` key of generated torrent with imdl version information.]' \
-'--no-creation-date[Do not populate `creation date` key of generated torrent with current time.]' \
-'-O[Open `.torrent` file after creation. Uses `xdg-open`, `gnome-open`, or `kde-open` on Linux; `open` on macOS; and `cmd /C start` on Windows]' \
-'--open[Open `.torrent` file after creation. Uses `xdg-open`, `gnome-open`, or `kde-open` on Linux; `open` on macOS; and `cmd /C start` on Windows]' \
-'-P[Set the `private` flag. Torrent clients that understand the flag and participate in the swarm of a torrent with the flag set will only announce themselves to the announce URLs included in the torrent, and will not use other peer discovery mechanisms, such as the DHT or local peer discovery. See BEP 27: Private Torrents for more information.]' \
-'--private[Set the `private` flag. Torrent clients that understand the flag and participate in the swarm of a torrent with the flag set will only announce themselves to the announce URLs included in the torrent, and will not use other peer discovery mechanisms, such as the DHT or local peer discovery. See BEP 27: Private Torrents for more information.]' \
-'-S[Display information about created torrent file.]' \
-'--show[Display information about created torrent file.]' \
-'--help[Print help message.]' \
-'-V[Print version number.]' \
-'--version[Print version number.]' \
-&& ret=0
-;;
-(link)
-_arguments "${_arguments_options[@]}" \
-'-i+[Generate magnet link from metainfo at `PATH`. If `PATH` is `-`, read metainfo from standard input.]' \
-'--input=[Generate magnet link from metainfo at `PATH`. If `PATH` is `-`, read metainfo from standard input.]' \
-'*-p+[Add `PEER` to magnet link.]' \
-'*--peer=[Add `PEER` to magnet link.]' \
-'-O[Open generated magnet link. Uses `xdg-open`, `gnome-open`, or `kde-open` on Linux; `open` on macOS; and `cmd /C start` on Windows]' \
-'--open[Open generated magnet link. Uses `xdg-open`, `gnome-open`, or `kde-open` on Linux; `open` on macOS; and `cmd /C start` on Windows]' \
-'-h[Print help message.]' \
-'--help[Print help message.]' \
-'-V[Print version number.]' \
-'--version[Print version number.]' \
-&& ret=0
-;;
-(piece-size)
-_arguments "${_arguments_options[@]}" \
-'-h[Print help message.]' \
-'--help[Print help message.]' \
-'-V[Print version number.]' \
-'--version[Print version number.]' \
-&& ret=0
-;;
-(piece-length)
-_arguments "${_arguments_options[@]}" \
-'-h[Print help message.]' \
-'--help[Print help message.]' \
-'-V[Print version number.]' \
-'--version[Print version number.]' \
-&& ret=0
-;;
-(show)
-_arguments "${_arguments_options[@]}" \
-'-i+[Show information about torrent at `PATH`. If `Path` is `-`, read torrent metainfo from standard input.]' \
-'--input=[Show information about torrent at `PATH`. If `Path` is `-`, read torrent metainfo from standard input.]' \
-'-h[Print help message.]' \
-'--help[Print help message.]' \
-'-V[Print version number.]' \
-'--version[Print version number.]' \
-&& ret=0
-;;
-(stats)
-_arguments "${_arguments_options[@]}" \
-'-l+[Stop after processing `N` torrents. Useful when processing large collections of `.torrent` files.]' \
-'--limit=[Stop after processing `N` torrents. Useful when processing large collections of `.torrent` files.]' \
-'*-e+[Extract and display values under key paths that match `REGEX`. Subkeys of a bencodeded dictionary are delimited by `/`, and values of a bencoded list are delmited by `*`. For example, given the following bencoded dictionary `{"foo": \[{"bar": {"baz": 2}}\]}`, the value `2`'\''s key path will be `foo*bar/baz`. The value `2` would be displayed if any of `bar`, `foo\[*\]bar/baz`, or `foo.*baz` were passed to `--extract-pattern.]' \
-'*--extract-pattern=[Extract and display values under key paths that match `REGEX`. Subkeys of a bencodeded dictionary are delimited by `/`, and values of a bencoded list are delmited by `*`. For example, given the following bencoded dictionary `{"foo": \[{"bar": {"baz": 2}}\]}`, the value `2`'\''s key path will be `foo*bar/baz`. The value `2` would be displayed if any of `bar`, `foo\[*\]bar/baz`, or `foo.*baz` were passed to `--extract-pattern.]' \
-'-i+[Search `PATH` for torrents. May be a directory or a single torrent file.]' \
-'--input=[Search `PATH` for torrents. May be a directory or a single torrent file.]' \
-'-p[Pretty print the contents of each torrent as it is processed.]' \
-'--print[Pretty print the contents of each torrent as it is processed.]' \
-'-h[Print help message.]' \
-'--help[Print help message.]' \
-'-V[Print version number.]' \
-'--version[Print version number.]' \
-&& ret=0
-;;
-(verify)
-_arguments "${_arguments_options[@]}" \
-'-i+[Verify torrent contents against torrent metainfo in `METAINFO`. If `METAINFO` is `-`, read metainfo from standard input.]' \
-'--input=[Verify torrent contents against torrent metainfo in `METAINFO`. If `METAINFO` is `-`, read metainfo from standard input.]' \
-'-c+[Verify torrent content at `PATH` against torrent metainfo. Defaults to `name` field of torrent info dictionary.]' \
-'--content=[Verify torrent content at `PATH` against torrent metainfo. Defaults to `name` field of torrent info dictionary.]' \
-'-h[Print help message.]' \
-'--help[Print help message.]' \
-'-V[Print version number.]' \
-'--version[Print version number.]' \
-&& ret=0
-;;
-(help)
-_arguments "${_arguments_options[@]}" \
-'-h[Prints help information]' \
-'--help[Prints help information]' \
-'-V[Prints version information]' \
-'--version[Prints version information]' \
-&& ret=0
-;;
-        esac
-    ;;
-esac
-;;
-(completions)
-_arguments "${_arguments_options[@]}" \
-'-s+[Print completions for `SHELL`.]: :(zsh bash fish powershell elvish)' \
-'--shell=[Print completions for `SHELL`.]: :(zsh bash fish powershell elvish)' \
-'-h[Print help message.]' \
-'--help[Print help message.]' \
-'-V[Print version number.]' \
-'--version[Print version number.]' \
-&& ret=0
-;;
-(help)
-_arguments "${_arguments_options[@]}" \
-'-h[Prints help information]' \
-'--help[Prints help information]' \
-'-V[Prints version information]' \
-'--version[Prints version information]' \
-&& ret=0
-;;
-        esac
-    ;;
-esac
-}
-
-(( $+functions[_imdl_commands] )) ||
-_imdl_commands() {
-    local commands; commands=(
-        "torrent:Subcommands related to the BitTorrent protocol." \
-"completions:Print shell completion scripts to standard output." \
-"help:Prints this message or the help of the given subcommand(s)" \
-    )
-    _describe -t commands 'imdl commands' commands "$@"
-}
-(( $+functions[_imdl__completions_commands] )) ||
-_imdl__completions_commands() {
-    local commands; commands=(
-        
-    )
-    _describe -t commands 'imdl completions commands' commands "$@"
-}
-(( $+functions[_imdl__torrent__create_commands] )) ||
-_imdl__torrent__create_commands() {
-    local commands; commands=(
-        
-    )
-    _describe -t commands 'imdl torrent create commands' commands "$@"
-}
-(( $+functions[_imdl__help_commands] )) ||
-_imdl__help_commands() {
-    local commands; commands=(
-        
-    )
-    _describe -t commands 'imdl help commands' commands "$@"
-}
-(( $+functions[_imdl__torrent__help_commands] )) ||
-_imdl__torrent__help_commands() {
-    local commands; commands=(
-        
-    )
-    _describe -t commands 'imdl torrent help commands' commands "$@"
-}
-(( $+functions[_imdl__torrent__link_commands] )) ||
-_imdl__torrent__link_commands() {
-    local commands; commands=(
-        
-    )
-    _describe -t commands 'imdl torrent link commands' commands "$@"
-}
-(( $+functions[_imdl__torrent__piece-length_commands] )) ||
-_imdl__torrent__piece-length_commands() {
-    local commands; commands=(
-        
-    )
-    _describe -t commands 'imdl torrent piece-length commands' commands "$@"
-}
-(( $+functions[_imdl__piece-size_commands] )) ||
-_imdl__piece-size_commands() {
-    local commands; commands=(
-        
-    )
-    _describe -t commands 'imdl piece-size commands' commands "$@"
-}
-(( $+functions[_imdl__torrent__piece-size_commands] )) ||
-_imdl__torrent__piece-size_commands() {
-    local commands; commands=(
-        
-    )
-    _describe -t commands 'imdl torrent piece-size commands' commands "$@"
-}
-(( $+functions[_imdl__torrent__show_commands] )) ||
-_imdl__torrent__show_commands() {
-    local commands; commands=(
-        
-    )
-    _describe -t commands 'imdl torrent show commands' commands "$@"
-}
-(( $+functions[_imdl__torrent__stats_commands] )) ||
-_imdl__torrent__stats_commands() {
-    local commands; commands=(
-        
-    )
-    _describe -t commands 'imdl torrent stats commands' commands "$@"
-}
-(( $+functions[_imdl__torrent_commands] )) ||
-_imdl__torrent_commands() {
-    local commands; commands=(
-        "create:Create a `.torrent` file." \
-"link:Generate a magnet link from a `.torrent` file." \
-"piece-length:Display information about automatic piece length selection." \
-"show:Display information about a `.torrent` file." \
-"stats:Show statistics about a collection of `.torrent` files." \
-"verify:Verify files against a `.torrent` file." \
-"help:Prints this message or the help of the given subcommand(s)" \
-    )
-    _describe -t commands 'imdl torrent commands' commands "$@"
-}
-(( $+functions[_imdl__torrent__verify_commands] )) ||
-_imdl__torrent__verify_commands() {
-    local commands; commands=(
-        
-    )
-    _describe -t commands 'imdl torrent verify commands' commands "$@"
-}
-
-_imdl "$@"
+    --sort-by size:ascending --sort-by path:descending'
+complete -c imdl -n "__fish_seen_subcommand_from create" -s o -l output -d 'Save `.torrent` file to `TARGET`, or print to standard output if `TARGET` is `-`. Defaults to `$INPUT.torrent`.'
+complete -c imdl -n "__fish_seen_subcommand_from create" -l peer -d 'Add `PEER` to magnet link.'
+complete -c imdl -n "__fish_seen_subcommand_from create" -s p -l piece-length -d 'Set piece length to `BYTES`. Accepts SI units, e.g. kib, mib, and gib.'
+complete -c imdl -n "__fish_seen_subcommand_from create" -s s -l source -d 'Set torrent source to `TEXT`. Stored under `source` key of info dictionary. This is useful for keeping statistics from being mis-reported when participating in swarms with the same contents, but with different trackers. When source is set to a unique value for torrents with the same contents, torrent clients will treat them as distinct torrents, and not share peers between them, and will correctly report download and upload statistics to multiple trackers.'
+complete -c imdl -n "__fish_seen_subcommand_from create" -s n -l dry-run -d 'Skip writing `.torrent` file to disk.'
+complete -c imdl -n "__fish_seen_subcommand_from create" -s F -l follow-symlinks -d 'Follow symlinks in torrent input. By default, symlinks to files and directories are not included in torrent contents.'
+complete -c imdl -n "__fish_seen_subcommand_from create" -s f -l force -d 'Overwrite the destination `.torrent` file, if it exists.'
+complete -c imdl -n "__fish_seen_subcommand_from create" -s h -l include-hidden -d 'Include hidden files that would otherwise be skipped, such as files that start with a `.`, and files hidden by file attributes on macOS and Windows.'
+complete -c imdl -n "__fish_seen_subcommand_from create" -s j -l include-junk -d 'Include junk files that would otherwise be skipped.'
+complete -c imdl -n "__fish_seen_subcommand_from create" -l link -d 'Print created torrent `magnet:` URL to standard output'
+complete -c imdl -n "__fish_seen_subcommand_from create" -s M -l md5 -d 'Include MD5 checksum of each file in the torrent. N.B. MD5 is cryptographically broken and only suitable for checking for accidental corruption.'
+complete -c imdl -n "__fish_seen_subcommand_from create" -l no-created-by -d 'Do not populate `created by` key of generated torrent with imdl version information.'
+complete -c imdl -n "__fish_seen_subcommand_from create" -l no-creation-date -d 'Do not populate `creation date` key of generated torrent with current time.'
+complete -c imdl -n "__fish_seen_subcommand_from create" -s O -l open -d 'Open `.torrent` file after creation. Uses `xdg-open`, `gnome-open`, or `kde-open` on Linux; `open` on macOS; and `cmd /C start` on Windows'
+complete -c imdl -n "__fish_seen_subcommand_from create" -s P -l private -d 'Set the `private` flag. Torrent clients that understand the flag and participate in the swarm of a torrent with the flag set will only announce themselves to the announce URLs included in the torrent, and will not use other peer discovery mechanisms, such as the DHT or local peer discovery. See BEP 27: Private Torrents for more information.'
+complete -c imdl -n "__fish_seen_subcommand_from create" -s S -l show -d 'Display information about created torrent file.'
+complete -c imdl -n "__fish_seen_subcommand_from create" -l help -d 'Print help message.'
+complete -c imdl -n "__fish_seen_subcommand_from create" -s V -l version -d 'Print version number.'
+complete -c imdl -n "__fish_seen_subcommand_from link" -s i -l input -d 'Generate magnet link from metainfo at `PATH`. If `PATH` is `-`, read metainfo from standard input.'
+complete -c imdl -n "__fish_seen_subcommand_from link" -s p -l peer -d 'Add `PEER` to magnet link.'
+complete -c imdl -n "__fish_seen_subcommand_from link" -s O -l open -d 'Open generated magnet link. Uses `xdg-open`, `gnome-open`, or `kde-open` on Linux; `open` on macOS; and `cmd /C start` on Windows'
+complete -c imdl -n "__fish_seen_subcommand_from link" -s h -l help -d 'Print help message.'
+complete -c imdl -n "__fish_seen_subcommand_from link" -s V -l version -d 'Print version number.'
+complete -c imdl -n "__fish_seen_subcommand_from piece-length" -s h -l help -d 'Print help message.'
+complete -c imdl -n "__fish_seen_subcommand_from piece-length" -s V -l version -d 'Print version number.'
+complete -c imdl -n "__fish_seen_subcommand_from show" -s i -l input -d 'Show information about torrent at `PATH`. If `Path` is `-`, read torrent metainfo from standard input.'
+complete -c imdl -n "__fish_seen_subcommand_from show" -s h -l help -d 'Print help message.'
+complete -c imdl -n "__fish_seen_subcommand_from show" -s V -l version -d 'Print version number.'
+complete -c imdl -n "__fish_seen_subcommand_from stats" -s l -l limit -d 'Stop after processing `N` torrents. Useful when processing large collections of `.torrent` files.'
+complete -c imdl -n "__fish_seen_subcommand_from stats" -s e -l extract-pattern -d 'Extract and display values under key paths that match `REGEX`. Subkeys of a bencodeded dictionary are delimited by `/`, and values of a bencoded list are delmited by `*`. For example, given the following bencoded dictionary `{"foo": [{"bar": {"baz": 2}}]}`, the value `2`\'s key path will be `foo*bar/baz`. The value `2` would be displayed if any of `bar`, `foo[*]bar/baz`, or `foo.*baz` were passed to `--extract-pattern.'
+complete -c imdl -n "__fish_seen_subcommand_from stats" -s i -l input -d 'Search `PATH` for torrents. May be a directory or a single torrent file.'
+complete -c imdl -n "__fish_seen_subcommand_from stats" -s p -l print -d 'Pretty print the contents of each torrent as it is processed.'
+complete -c imdl -n "__fish_seen_subcommand_from stats" -s h -l help -d 'Print help message.'
+complete -c imdl -n "__fish_seen_subcommand_from stats" -s V -l version -d 'Print version number.'
+complete -c imdl -n "__fish_seen_subcommand_from verify" -s i -l input -d 'Verify torrent contents against torrent metainfo in `METAINFO`. If `METAINFO` is `-`, read metainfo from standard input.'
+complete -c imdl -n "__fish_seen_subcommand_from verify" -s c -l content -d 'Verify torrent content at `PATH` against torrent metainfo. Defaults to `name` field of torrent info dictionary.'
+complete -c imdl -n "__fish_seen_subcommand_from verify" -s h -l help -d 'Print help message.'
+complete -c imdl -n "__fish_seen_subcommand_from verify" -s V -l version -d 'Print version number.'
+complete -c imdl -n "__fish_seen_subcommand_from help" -s h -l help -d 'Prints help information'
+complete -c imdl -n "__fish_seen_subcommand_from help" -s V -l version -d 'Prints version information'
+complete -c imdl -n "__fish_seen_subcommand_from completions" -s s -l shell -d 'Print completions for `SHELL`.' -r -f -a "zsh bash fish powershell elvish"
+complete -c imdl -n "__fish_seen_subcommand_from completions" -s h -l help -d 'Print help message.'
+complete -c imdl -n "__fish_seen_subcommand_from completions" -s V -l version -d 'Print version number.'
+complete -c imdl -n "__fish_seen_subcommand_from help" -s h -l help -d 'Prints help information'
+complete -c imdl -n "__fish_seen_subcommand_from help" -s V -l version -d 'Prints version information'

--- a/completions/imdl.fish
+++ b/completions/imdl.fish
@@ -1,0 +1,335 @@
+#compdef imdl
+
+autoload -U is-at-least
+
+_imdl() {
+    typeset -A opt_args
+    typeset -a _arguments_options
+    local ret=1
+
+    if is-at-least 5.2; then
+        _arguments_options=(-s -S -C)
+    else
+        _arguments_options=(-s -C)
+    fi
+
+    local context curcontext="$curcontext" state line
+    _arguments "${_arguments_options[@]}" \
+'--color=[Print colorful output according to `WHEN`. When `auto`, the default, colored output is only enabled if imdl detects that it is connected to a terminal, the `NO_COLOR` environment variable is not set, and the `TERM` environment variable is not set to `dumb`.]: :(auto always never)' \
+'-u[Enable unstable features. To avoid premature stabilization and excessive version churn, unstable features are unavailable unless this flag is set. Unstable features are not bound by semantic versioning stability guarantees, and may be changed or removed at any time.]' \
+'--unstable[Enable unstable features. To avoid premature stabilization and excessive version churn, unstable features are unavailable unless this flag is set. Unstable features are not bound by semantic versioning stability guarantees, and may be changed or removed at any time.]' \
+'-h[Print help message.]' \
+'--help[Print help message.]' \
+'-V[Print version number.]' \
+'--version[Print version number.]' \
+":: :_imdl_commands" \
+"*::: :->imdl" \
+&& ret=0
+    case $state in
+    (imdl)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:imdl-command-$line[1]:"
+        case $line[1] in
+            (torrent)
+_arguments "${_arguments_options[@]}" \
+'-h[Print help message.]' \
+'--help[Print help message.]' \
+'-V[Print version number.]' \
+'--version[Print version number.]' \
+":: :_imdl__torrent_commands" \
+"*::: :->torrent" \
+&& ret=0
+case $state in
+    (torrent)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:imdl-torrent-command-$line[1]:"
+        case $line[1] in
+            (create)
+_arguments "${_arguments_options[@]}" \
+'-a+[Use `URL` as the primary tracker announce URL. To supply multiple announce URLs, also use `--announce-tier`.]' \
+'--announce=[Use `URL` as the primary tracker announce URL. To supply multiple announce URLs, also use `--announce-tier`.]' \
+'*-A+[Allow `LINT`. Lints check for conditions which, although permitted, are not usually desirable. For example, piece length can be any non-zero value, but probably shouldn'\''t be below 16 KiB. The lint `small-piece-size` checks for this, and `--allow small-piece-size` can be used to disable this check.]: :(private-trackerless small-piece-length uneven-piece-length)' \
+'*--allow=[Allow `LINT`. Lints check for conditions which, although permitted, are not usually desirable. For example, piece length can be any non-zero value, but probably shouldn'\''t be below 16 KiB. The lint `small-piece-size` checks for this, and `--allow small-piece-size` can be used to disable this check.]: :(private-trackerless small-piece-length uneven-piece-length)' \
+'*-t+[Use `URL-LIST` as a tracker announce tier. Each instance adds a new tier. To add multiple trackers to a given tier, separate their announce URLs with commas:
+
+`--announce-tier udp://example.com:80/announce,https://example.net:443/announce`
+            
+Announce tiers are stored in the `announce-list` key of the top-level metainfo dictionary as a list of lists of strings, as defined by BEP 12: Multitracker Metadata Extension.
+            
+Note: Many BitTorrent clients do not implement the behavior described in BEP 12. See the discussion here for more details: https://github.com/bittorrent/bittorrent.org/issues/82]' \
+'*--announce-tier=[Use `URL-LIST` as a tracker announce tier. Each instance adds a new tier. To add multiple trackers to a given tier, separate their announce URLs with commas:
+
+`--announce-tier udp://example.com:80/announce,https://example.net:443/announce`
+            
+Announce tiers are stored in the `announce-list` key of the top-level metainfo dictionary as a list of lists of strings, as defined by BEP 12: Multitracker Metadata Extension.
+            
+Note: Many BitTorrent clients do not implement the behavior described in BEP 12. See the discussion here for more details: https://github.com/bittorrent/bittorrent.org/issues/82]' \
+'-c+[Include `TEXT` as the comment for generated `.torrent` file. Stored under `comment` key of top-level metainfo dictionary.]' \
+'--comment=[Include `TEXT` as the comment for generated `.torrent` file. Stored under `comment` key of top-level metainfo dictionary.]' \
+'*--node=[Add DHT bootstrap node `NODE` to torrent. `NODE` should be in the form `HOST:PORT`, where `HOST` is a domain name, an IPv4 address, or an IPv6 address surrounded by brackets. May be given more than once to add multiple bootstrap nodes.
+
+Examples:
+
+    --node router.example.com:1337
+
+    --node 203.0.113.0:2290
+
+    --node \[2001:db8:4275:7920:6269:7463:6f69:6e21\]:8832]' \
+'*-g+[Include or exclude files that match `GLOB`. Multiple glob may be provided, with the last one taking precedence. Precede a glob with `!` to exclude it.]' \
+'*--glob=[Include or exclude files that match `GLOB`. Multiple glob may be provided, with the last one taking precedence. Precede a glob with `!` to exclude it.]' \
+'-i+[Read torrent contents from `PATH`. If `PATH` is a file, torrent will be a single-file torrent, if `PATH` is a directory, torrent will be a multi-file torrent.]' \
+'--input=[Read torrent contents from `PATH`. If `PATH` is a file, torrent will be a single-file torrent, if `PATH` is a directory, torrent will be a multi-file torrent.]' \
+'-N+[Set name of torrent to `TEXT`. Defaults to the filename of the argument to `--input`.]' \
+'--name=[Set name of torrent to `TEXT`. Defaults to the filename of the argument to `--input`.]' \
+'*--sort-by=[Set the order of files within a torrent. `SPEC` should be of the form `KEY:ORDER`, with `KEY` being one of `path` or `size`, and `ORDER` being `ascending` or `descending`. `:ORDER` defaults to `ascending` if omitted. The `--sort-by` flag may be given more than once, with later values being used to break ties. Ties that remain are broken in ascending path order.
+
+Sort in ascending order by path, the default:
+
+    --sort-by path:ascending
+
+Sort in ascending order by path, more concisely:
+
+    --sort-by path
+
+Sort in ascending order by size, break ties in descending path order:
+
+    --sort-by size:ascending --sort-by path:descending]' \
+'-o+[Save `.torrent` file to `TARGET`, or print to standard output if `TARGET` is `-`. Defaults to `$INPUT.torrent`.]' \
+'--output=[Save `.torrent` file to `TARGET`, or print to standard output if `TARGET` is `-`. Defaults to `$INPUT.torrent`.]' \
+'*--peer=[Add `PEER` to magnet link.]' \
+'-p+[Set piece length to `BYTES`. Accepts SI units, e.g. kib, mib, and gib.]' \
+'--piece-length=[Set piece length to `BYTES`. Accepts SI units, e.g. kib, mib, and gib.]' \
+'-s+[Set torrent source to `TEXT`. Stored under `source` key of info dictionary. This is useful for keeping statistics from being mis-reported when participating in swarms with the same contents, but with different trackers. When source is set to a unique value for torrents with the same contents, torrent clients will treat them as distinct torrents, and not share peers between them, and will correctly report download and upload statistics to multiple trackers.]' \
+'--source=[Set torrent source to `TEXT`. Stored under `source` key of info dictionary. This is useful for keeping statistics from being mis-reported when participating in swarms with the same contents, but with different trackers. When source is set to a unique value for torrents with the same contents, torrent clients will treat them as distinct torrents, and not share peers between them, and will correctly report download and upload statistics to multiple trackers.]' \
+'-n[Skip writing `.torrent` file to disk.]' \
+'--dry-run[Skip writing `.torrent` file to disk.]' \
+'-F[Follow symlinks in torrent input. By default, symlinks to files and directories are not included in torrent contents.]' \
+'--follow-symlinks[Follow symlinks in torrent input. By default, symlinks to files and directories are not included in torrent contents.]' \
+'-f[Overwrite the destination `.torrent` file, if it exists.]' \
+'--force[Overwrite the destination `.torrent` file, if it exists.]' \
+'-h[Include hidden files that would otherwise be skipped, such as files that start with a `.`, and files hidden by file attributes on macOS and Windows.]' \
+'--include-hidden[Include hidden files that would otherwise be skipped, such as files that start with a `.`, and files hidden by file attributes on macOS and Windows.]' \
+'-j[Include junk files that would otherwise be skipped.]' \
+'--include-junk[Include junk files that would otherwise be skipped.]' \
+'--link[Print created torrent `magnet:` URL to standard output]' \
+'-M[Include MD5 checksum of each file in the torrent. N.B. MD5 is cryptographically broken and only suitable for checking for accidental corruption.]' \
+'--md5[Include MD5 checksum of each file in the torrent. N.B. MD5 is cryptographically broken and only suitable for checking for accidental corruption.]' \
+'--no-created-by[Do not populate `created by` key of generated torrent with imdl version information.]' \
+'--no-creation-date[Do not populate `creation date` key of generated torrent with current time.]' \
+'-O[Open `.torrent` file after creation. Uses `xdg-open`, `gnome-open`, or `kde-open` on Linux; `open` on macOS; and `cmd /C start` on Windows]' \
+'--open[Open `.torrent` file after creation. Uses `xdg-open`, `gnome-open`, or `kde-open` on Linux; `open` on macOS; and `cmd /C start` on Windows]' \
+'-P[Set the `private` flag. Torrent clients that understand the flag and participate in the swarm of a torrent with the flag set will only announce themselves to the announce URLs included in the torrent, and will not use other peer discovery mechanisms, such as the DHT or local peer discovery. See BEP 27: Private Torrents for more information.]' \
+'--private[Set the `private` flag. Torrent clients that understand the flag and participate in the swarm of a torrent with the flag set will only announce themselves to the announce URLs included in the torrent, and will not use other peer discovery mechanisms, such as the DHT or local peer discovery. See BEP 27: Private Torrents for more information.]' \
+'-S[Display information about created torrent file.]' \
+'--show[Display information about created torrent file.]' \
+'--help[Print help message.]' \
+'-V[Print version number.]' \
+'--version[Print version number.]' \
+&& ret=0
+;;
+(link)
+_arguments "${_arguments_options[@]}" \
+'-i+[Generate magnet link from metainfo at `PATH`. If `PATH` is `-`, read metainfo from standard input.]' \
+'--input=[Generate magnet link from metainfo at `PATH`. If `PATH` is `-`, read metainfo from standard input.]' \
+'*-p+[Add `PEER` to magnet link.]' \
+'*--peer=[Add `PEER` to magnet link.]' \
+'-O[Open generated magnet link. Uses `xdg-open`, `gnome-open`, or `kde-open` on Linux; `open` on macOS; and `cmd /C start` on Windows]' \
+'--open[Open generated magnet link. Uses `xdg-open`, `gnome-open`, or `kde-open` on Linux; `open` on macOS; and `cmd /C start` on Windows]' \
+'-h[Print help message.]' \
+'--help[Print help message.]' \
+'-V[Print version number.]' \
+'--version[Print version number.]' \
+&& ret=0
+;;
+(piece-size)
+_arguments "${_arguments_options[@]}" \
+'-h[Print help message.]' \
+'--help[Print help message.]' \
+'-V[Print version number.]' \
+'--version[Print version number.]' \
+&& ret=0
+;;
+(piece-length)
+_arguments "${_arguments_options[@]}" \
+'-h[Print help message.]' \
+'--help[Print help message.]' \
+'-V[Print version number.]' \
+'--version[Print version number.]' \
+&& ret=0
+;;
+(show)
+_arguments "${_arguments_options[@]}" \
+'-i+[Show information about torrent at `PATH`. If `Path` is `-`, read torrent metainfo from standard input.]' \
+'--input=[Show information about torrent at `PATH`. If `Path` is `-`, read torrent metainfo from standard input.]' \
+'-h[Print help message.]' \
+'--help[Print help message.]' \
+'-V[Print version number.]' \
+'--version[Print version number.]' \
+&& ret=0
+;;
+(stats)
+_arguments "${_arguments_options[@]}" \
+'-l+[Stop after processing `N` torrents. Useful when processing large collections of `.torrent` files.]' \
+'--limit=[Stop after processing `N` torrents. Useful when processing large collections of `.torrent` files.]' \
+'*-e+[Extract and display values under key paths that match `REGEX`. Subkeys of a bencodeded dictionary are delimited by `/`, and values of a bencoded list are delmited by `*`. For example, given the following bencoded dictionary `{"foo": \[{"bar": {"baz": 2}}\]}`, the value `2`'\''s key path will be `foo*bar/baz`. The value `2` would be displayed if any of `bar`, `foo\[*\]bar/baz`, or `foo.*baz` were passed to `--extract-pattern.]' \
+'*--extract-pattern=[Extract and display values under key paths that match `REGEX`. Subkeys of a bencodeded dictionary are delimited by `/`, and values of a bencoded list are delmited by `*`. For example, given the following bencoded dictionary `{"foo": \[{"bar": {"baz": 2}}\]}`, the value `2`'\''s key path will be `foo*bar/baz`. The value `2` would be displayed if any of `bar`, `foo\[*\]bar/baz`, or `foo.*baz` were passed to `--extract-pattern.]' \
+'-i+[Search `PATH` for torrents. May be a directory or a single torrent file.]' \
+'--input=[Search `PATH` for torrents. May be a directory or a single torrent file.]' \
+'-p[Pretty print the contents of each torrent as it is processed.]' \
+'--print[Pretty print the contents of each torrent as it is processed.]' \
+'-h[Print help message.]' \
+'--help[Print help message.]' \
+'-V[Print version number.]' \
+'--version[Print version number.]' \
+&& ret=0
+;;
+(verify)
+_arguments "${_arguments_options[@]}" \
+'-i+[Verify torrent contents against torrent metainfo in `METAINFO`. If `METAINFO` is `-`, read metainfo from standard input.]' \
+'--input=[Verify torrent contents against torrent metainfo in `METAINFO`. If `METAINFO` is `-`, read metainfo from standard input.]' \
+'-c+[Verify torrent content at `PATH` against torrent metainfo. Defaults to `name` field of torrent info dictionary.]' \
+'--content=[Verify torrent content at `PATH` against torrent metainfo. Defaults to `name` field of torrent info dictionary.]' \
+'-h[Print help message.]' \
+'--help[Print help message.]' \
+'-V[Print version number.]' \
+'--version[Print version number.]' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" \
+'-h[Prints help information]' \
+'--help[Prints help information]' \
+'-V[Prints version information]' \
+'--version[Prints version information]' \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(completions)
+_arguments "${_arguments_options[@]}" \
+'-s+[Print completions for `SHELL`.]: :(zsh bash fish powershell elvish)' \
+'--shell=[Print completions for `SHELL`.]: :(zsh bash fish powershell elvish)' \
+'-h[Print help message.]' \
+'--help[Print help message.]' \
+'-V[Print version number.]' \
+'--version[Print version number.]' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" \
+'-h[Prints help information]' \
+'--help[Prints help information]' \
+'-V[Prints version information]' \
+'--version[Prints version information]' \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+}
+
+(( $+functions[_imdl_commands] )) ||
+_imdl_commands() {
+    local commands; commands=(
+        "torrent:Subcommands related to the BitTorrent protocol." \
+"completions:Print shell completion scripts to standard output." \
+"help:Prints this message or the help of the given subcommand(s)" \
+    )
+    _describe -t commands 'imdl commands' commands "$@"
+}
+(( $+functions[_imdl__completions_commands] )) ||
+_imdl__completions_commands() {
+    local commands; commands=(
+        
+    )
+    _describe -t commands 'imdl completions commands' commands "$@"
+}
+(( $+functions[_imdl__torrent__create_commands] )) ||
+_imdl__torrent__create_commands() {
+    local commands; commands=(
+        
+    )
+    _describe -t commands 'imdl torrent create commands' commands "$@"
+}
+(( $+functions[_imdl__help_commands] )) ||
+_imdl__help_commands() {
+    local commands; commands=(
+        
+    )
+    _describe -t commands 'imdl help commands' commands "$@"
+}
+(( $+functions[_imdl__torrent__help_commands] )) ||
+_imdl__torrent__help_commands() {
+    local commands; commands=(
+        
+    )
+    _describe -t commands 'imdl torrent help commands' commands "$@"
+}
+(( $+functions[_imdl__torrent__link_commands] )) ||
+_imdl__torrent__link_commands() {
+    local commands; commands=(
+        
+    )
+    _describe -t commands 'imdl torrent link commands' commands "$@"
+}
+(( $+functions[_imdl__torrent__piece-length_commands] )) ||
+_imdl__torrent__piece-length_commands() {
+    local commands; commands=(
+        
+    )
+    _describe -t commands 'imdl torrent piece-length commands' commands "$@"
+}
+(( $+functions[_imdl__piece-size_commands] )) ||
+_imdl__piece-size_commands() {
+    local commands; commands=(
+        
+    )
+    _describe -t commands 'imdl piece-size commands' commands "$@"
+}
+(( $+functions[_imdl__torrent__piece-size_commands] )) ||
+_imdl__torrent__piece-size_commands() {
+    local commands; commands=(
+        
+    )
+    _describe -t commands 'imdl torrent piece-size commands' commands "$@"
+}
+(( $+functions[_imdl__torrent__show_commands] )) ||
+_imdl__torrent__show_commands() {
+    local commands; commands=(
+        
+    )
+    _describe -t commands 'imdl torrent show commands' commands "$@"
+}
+(( $+functions[_imdl__torrent__stats_commands] )) ||
+_imdl__torrent__stats_commands() {
+    local commands; commands=(
+        
+    )
+    _describe -t commands 'imdl torrent stats commands' commands "$@"
+}
+(( $+functions[_imdl__torrent_commands] )) ||
+_imdl__torrent_commands() {
+    local commands; commands=(
+        "create:Create a `.torrent` file." \
+"link:Generate a magnet link from a `.torrent` file." \
+"piece-length:Display information about automatic piece length selection." \
+"show:Display information about a `.torrent` file." \
+"stats:Show statistics about a collection of `.torrent` files." \
+"verify:Verify files against a `.torrent` file." \
+"help:Prints this message or the help of the given subcommand(s)" \
+    )
+    _describe -t commands 'imdl torrent commands' commands "$@"
+}
+(( $+functions[_imdl__torrent__verify_commands] )) ||
+_imdl__torrent__verify_commands() {
+    local commands; commands=(
+        
+    )
+    _describe -t commands 'imdl torrent verify commands' commands "$@"
+}
+
+_imdl "$@"

--- a/completions/imdl.powershell
+++ b/completions/imdl.powershell
@@ -1,0 +1,212 @@
+using namespace System.Management.Automation
+using namespace System.Management.Automation.Language
+
+Register-ArgumentCompleter -Native -CommandName 'imdl' -ScriptBlock {
+    param($wordToComplete, $commandAst, $cursorPosition)
+
+    $commandElements = $commandAst.CommandElements
+    $command = @(
+        'imdl'
+        for ($i = 1; $i -lt $commandElements.Count; $i++) {
+            $element = $commandElements[$i]
+            if ($element -isnot [StringConstantExpressionAst] -or
+                $element.StringConstantType -ne [StringConstantType]::BareWord -or
+                $element.Value.StartsWith('-')) {
+                break
+        }
+        $element.Value
+    }) -join ';'
+
+    $completions = @(switch ($command) {
+        'imdl' {
+            [CompletionResult]::new('--color', 'color', [CompletionResultType]::ParameterName, 'Print colorful output according to `WHEN`. When `auto`, the default, colored output is only enabled if imdl detects that it is connected to a terminal, the `NO_COLOR` environment variable is not set, and the `TERM` environment variable is not set to `dumb`.')
+            [CompletionResult]::new('-u', 'u', [CompletionResultType]::ParameterName, 'Enable unstable features. To avoid premature stabilization and excessive version churn, unstable features are unavailable unless this flag is set. Unstable features are not bound by semantic versioning stability guarantees, and may be changed or removed at any time.')
+            [CompletionResult]::new('--unstable', 'unstable', [CompletionResultType]::ParameterName, 'Enable unstable features. To avoid premature stabilization and excessive version churn, unstable features are unavailable unless this flag is set. Unstable features are not bound by semantic versioning stability guarantees, and may be changed or removed at any time.')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help message.')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help message.')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version number.')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version number.')
+            [CompletionResult]::new('torrent', 'torrent', [CompletionResultType]::ParameterValue, 'Subcommands related to the BitTorrent protocol.')
+            [CompletionResult]::new('completions', 'completions', [CompletionResultType]::ParameterValue, 'Print shell completion scripts to standard output.')
+            [CompletionResult]::new('help', 'help', [CompletionResultType]::ParameterValue, 'Prints this message or the help of the given subcommand(s)')
+            break
+        }
+        'imdl;torrent' {
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help message.')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help message.')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version number.')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version number.')
+            [CompletionResult]::new('create', 'create', [CompletionResultType]::ParameterValue, 'Create a `.torrent` file.')
+            [CompletionResult]::new('link', 'link', [CompletionResultType]::ParameterValue, 'Generate a magnet link from a `.torrent` file.')
+            [CompletionResult]::new('piece-length', 'piece-length', [CompletionResultType]::ParameterValue, 'Display information about automatic piece length selection.')
+            [CompletionResult]::new('show', 'show', [CompletionResultType]::ParameterValue, 'Display information about a `.torrent` file.')
+            [CompletionResult]::new('stats', 'stats', [CompletionResultType]::ParameterValue, 'Show statistics about a collection of `.torrent` files.')
+            [CompletionResult]::new('verify', 'verify', [CompletionResultType]::ParameterValue, 'Verify files against a `.torrent` file.')
+            [CompletionResult]::new('help', 'help', [CompletionResultType]::ParameterValue, 'Prints this message or the help of the given subcommand(s)')
+            break
+        }
+        'imdl;torrent;create' {
+            [CompletionResult]::new('-a', 'a', [CompletionResultType]::ParameterName, 'Use `URL` as the primary tracker announce URL. To supply multiple announce URLs, also use `--announce-tier`.')
+            [CompletionResult]::new('--announce', 'announce', [CompletionResultType]::ParameterName, 'Use `URL` as the primary tracker announce URL. To supply multiple announce URLs, also use `--announce-tier`.')
+            [CompletionResult]::new('-A', 'A', [CompletionResultType]::ParameterName, 'Allow `LINT`. Lints check for conditions which, although permitted, are not usually desirable. For example, piece length can be any non-zero value, but probably shouldn''t be below 16 KiB. The lint `small-piece-size` checks for this, and `--allow small-piece-size` can be used to disable this check.')
+            [CompletionResult]::new('--allow', 'allow', [CompletionResultType]::ParameterName, 'Allow `LINT`. Lints check for conditions which, although permitted, are not usually desirable. For example, piece length can be any non-zero value, but probably shouldn''t be below 16 KiB. The lint `small-piece-size` checks for this, and `--allow small-piece-size` can be used to disable this check.')
+            [CompletionResult]::new('-t', 't', [CompletionResultType]::ParameterName, 'Use `URL-LIST` as a tracker announce tier. Each instance adds a new tier. To add multiple trackers to a given tier, separate their announce URLs with commas:
+
+`--announce-tier udp://example.com:80/announce,https://example.net:443/announce`
+            
+Announce tiers are stored in the `announce-list` key of the top-level metainfo dictionary as a list of lists of strings, as defined by BEP 12: Multitracker Metadata Extension.
+            
+Note: Many BitTorrent clients do not implement the behavior described in BEP 12. See the discussion here for more details: https://github.com/bittorrent/bittorrent.org/issues/82')
+            [CompletionResult]::new('--announce-tier', 'announce-tier', [CompletionResultType]::ParameterName, 'Use `URL-LIST` as a tracker announce tier. Each instance adds a new tier. To add multiple trackers to a given tier, separate their announce URLs with commas:
+
+`--announce-tier udp://example.com:80/announce,https://example.net:443/announce`
+            
+Announce tiers are stored in the `announce-list` key of the top-level metainfo dictionary as a list of lists of strings, as defined by BEP 12: Multitracker Metadata Extension.
+            
+Note: Many BitTorrent clients do not implement the behavior described in BEP 12. See the discussion here for more details: https://github.com/bittorrent/bittorrent.org/issues/82')
+            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'Include `TEXT` as the comment for generated `.torrent` file. Stored under `comment` key of top-level metainfo dictionary.')
+            [CompletionResult]::new('--comment', 'comment', [CompletionResultType]::ParameterName, 'Include `TEXT` as the comment for generated `.torrent` file. Stored under `comment` key of top-level metainfo dictionary.')
+            [CompletionResult]::new('--node', 'node', [CompletionResultType]::ParameterName, 'Add DHT bootstrap node `NODE` to torrent. `NODE` should be in the form `HOST:PORT`, where `HOST` is a domain name, an IPv4 address, or an IPv6 address surrounded by brackets. May be given more than once to add multiple bootstrap nodes.
+
+Examples:
+
+    --node router.example.com:1337
+
+    --node 203.0.113.0:2290
+
+    --node [2001:db8:4275:7920:6269:7463:6f69:6e21]:8832')
+            [CompletionResult]::new('-g', 'g', [CompletionResultType]::ParameterName, 'Include or exclude files that match `GLOB`. Multiple glob may be provided, with the last one taking precedence. Precede a glob with `!` to exclude it.')
+            [CompletionResult]::new('--glob', 'glob', [CompletionResultType]::ParameterName, 'Include or exclude files that match `GLOB`. Multiple glob may be provided, with the last one taking precedence. Precede a glob with `!` to exclude it.')
+            [CompletionResult]::new('-i', 'i', [CompletionResultType]::ParameterName, 'Read torrent contents from `PATH`. If `PATH` is a file, torrent will be a single-file torrent, if `PATH` is a directory, torrent will be a multi-file torrent.')
+            [CompletionResult]::new('--input', 'input', [CompletionResultType]::ParameterName, 'Read torrent contents from `PATH`. If `PATH` is a file, torrent will be a single-file torrent, if `PATH` is a directory, torrent will be a multi-file torrent.')
+            [CompletionResult]::new('-N', 'N', [CompletionResultType]::ParameterName, 'Set name of torrent to `TEXT`. Defaults to the filename of the argument to `--input`.')
+            [CompletionResult]::new('--name', 'name', [CompletionResultType]::ParameterName, 'Set name of torrent to `TEXT`. Defaults to the filename of the argument to `--input`.')
+            [CompletionResult]::new('--sort-by', 'sort-by', [CompletionResultType]::ParameterName, 'Set the order of files within a torrent. `SPEC` should be of the form `KEY:ORDER`, with `KEY` being one of `path` or `size`, and `ORDER` being `ascending` or `descending`. `:ORDER` defaults to `ascending` if omitted. The `--sort-by` flag may be given more than once, with later values being used to break ties. Ties that remain are broken in ascending path order.
+
+Sort in ascending order by path, the default:
+
+    --sort-by path:ascending
+
+Sort in ascending order by path, more concisely:
+
+    --sort-by path
+
+Sort in ascending order by size, break ties in descending path order:
+
+    --sort-by size:ascending --sort-by path:descending')
+            [CompletionResult]::new('-o', 'o', [CompletionResultType]::ParameterName, 'Save `.torrent` file to `TARGET`, or print to standard output if `TARGET` is `-`. Defaults to `$INPUT.torrent`.')
+            [CompletionResult]::new('--output', 'output', [CompletionResultType]::ParameterName, 'Save `.torrent` file to `TARGET`, or print to standard output if `TARGET` is `-`. Defaults to `$INPUT.torrent`.')
+            [CompletionResult]::new('--peer', 'peer', [CompletionResultType]::ParameterName, 'Add `PEER` to magnet link.')
+            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'Set piece length to `BYTES`. Accepts SI units, e.g. kib, mib, and gib.')
+            [CompletionResult]::new('--piece-length', 'piece-length', [CompletionResultType]::ParameterName, 'Set piece length to `BYTES`. Accepts SI units, e.g. kib, mib, and gib.')
+            [CompletionResult]::new('-s', 's', [CompletionResultType]::ParameterName, 'Set torrent source to `TEXT`. Stored under `source` key of info dictionary. This is useful for keeping statistics from being mis-reported when participating in swarms with the same contents, but with different trackers. When source is set to a unique value for torrents with the same contents, torrent clients will treat them as distinct torrents, and not share peers between them, and will correctly report download and upload statistics to multiple trackers.')
+            [CompletionResult]::new('--source', 'source', [CompletionResultType]::ParameterName, 'Set torrent source to `TEXT`. Stored under `source` key of info dictionary. This is useful for keeping statistics from being mis-reported when participating in swarms with the same contents, but with different trackers. When source is set to a unique value for torrents with the same contents, torrent clients will treat them as distinct torrents, and not share peers between them, and will correctly report download and upload statistics to multiple trackers.')
+            [CompletionResult]::new('-n', 'n', [CompletionResultType]::ParameterName, 'Skip writing `.torrent` file to disk.')
+            [CompletionResult]::new('--dry-run', 'dry-run', [CompletionResultType]::ParameterName, 'Skip writing `.torrent` file to disk.')
+            [CompletionResult]::new('-F', 'F', [CompletionResultType]::ParameterName, 'Follow symlinks in torrent input. By default, symlinks to files and directories are not included in torrent contents.')
+            [CompletionResult]::new('--follow-symlinks', 'follow-symlinks', [CompletionResultType]::ParameterName, 'Follow symlinks in torrent input. By default, symlinks to files and directories are not included in torrent contents.')
+            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'Overwrite the destination `.torrent` file, if it exists.')
+            [CompletionResult]::new('--force', 'force', [CompletionResultType]::ParameterName, 'Overwrite the destination `.torrent` file, if it exists.')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Include hidden files that would otherwise be skipped, such as files that start with a `.`, and files hidden by file attributes on macOS and Windows.')
+            [CompletionResult]::new('--include-hidden', 'include-hidden', [CompletionResultType]::ParameterName, 'Include hidden files that would otherwise be skipped, such as files that start with a `.`, and files hidden by file attributes on macOS and Windows.')
+            [CompletionResult]::new('-j', 'j', [CompletionResultType]::ParameterName, 'Include junk files that would otherwise be skipped.')
+            [CompletionResult]::new('--include-junk', 'include-junk', [CompletionResultType]::ParameterName, 'Include junk files that would otherwise be skipped.')
+            [CompletionResult]::new('--link', 'link', [CompletionResultType]::ParameterName, 'Print created torrent `magnet:` URL to standard output')
+            [CompletionResult]::new('-M', 'M', [CompletionResultType]::ParameterName, 'Include MD5 checksum of each file in the torrent. N.B. MD5 is cryptographically broken and only suitable for checking for accidental corruption.')
+            [CompletionResult]::new('--md5', 'md5', [CompletionResultType]::ParameterName, 'Include MD5 checksum of each file in the torrent. N.B. MD5 is cryptographically broken and only suitable for checking for accidental corruption.')
+            [CompletionResult]::new('--no-created-by', 'no-created-by', [CompletionResultType]::ParameterName, 'Do not populate `created by` key of generated torrent with imdl version information.')
+            [CompletionResult]::new('--no-creation-date', 'no-creation-date', [CompletionResultType]::ParameterName, 'Do not populate `creation date` key of generated torrent with current time.')
+            [CompletionResult]::new('-O', 'O', [CompletionResultType]::ParameterName, 'Open `.torrent` file after creation. Uses `xdg-open`, `gnome-open`, or `kde-open` on Linux; `open` on macOS; and `cmd /C start` on Windows')
+            [CompletionResult]::new('--open', 'open', [CompletionResultType]::ParameterName, 'Open `.torrent` file after creation. Uses `xdg-open`, `gnome-open`, or `kde-open` on Linux; `open` on macOS; and `cmd /C start` on Windows')
+            [CompletionResult]::new('-P', 'P', [CompletionResultType]::ParameterName, 'Set the `private` flag. Torrent clients that understand the flag and participate in the swarm of a torrent with the flag set will only announce themselves to the announce URLs included in the torrent, and will not use other peer discovery mechanisms, such as the DHT or local peer discovery. See BEP 27: Private Torrents for more information.')
+            [CompletionResult]::new('--private', 'private', [CompletionResultType]::ParameterName, 'Set the `private` flag. Torrent clients that understand the flag and participate in the swarm of a torrent with the flag set will only announce themselves to the announce URLs included in the torrent, and will not use other peer discovery mechanisms, such as the DHT or local peer discovery. See BEP 27: Private Torrents for more information.')
+            [CompletionResult]::new('-S', 'S', [CompletionResultType]::ParameterName, 'Display information about created torrent file.')
+            [CompletionResult]::new('--show', 'show', [CompletionResultType]::ParameterName, 'Display information about created torrent file.')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help message.')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version number.')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version number.')
+            break
+        }
+        'imdl;torrent;link' {
+            [CompletionResult]::new('-i', 'i', [CompletionResultType]::ParameterName, 'Generate magnet link from metainfo at `PATH`. If `PATH` is `-`, read metainfo from standard input.')
+            [CompletionResult]::new('--input', 'input', [CompletionResultType]::ParameterName, 'Generate magnet link from metainfo at `PATH`. If `PATH` is `-`, read metainfo from standard input.')
+            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'Add `PEER` to magnet link.')
+            [CompletionResult]::new('--peer', 'peer', [CompletionResultType]::ParameterName, 'Add `PEER` to magnet link.')
+            [CompletionResult]::new('-O', 'O', [CompletionResultType]::ParameterName, 'Open generated magnet link. Uses `xdg-open`, `gnome-open`, or `kde-open` on Linux; `open` on macOS; and `cmd /C start` on Windows')
+            [CompletionResult]::new('--open', 'open', [CompletionResultType]::ParameterName, 'Open generated magnet link. Uses `xdg-open`, `gnome-open`, or `kde-open` on Linux; `open` on macOS; and `cmd /C start` on Windows')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help message.')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help message.')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version number.')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version number.')
+            break
+        }
+        'imdl;torrent;piece-length' {
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help message.')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help message.')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version number.')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version number.')
+            break
+        }
+        'imdl;torrent;show' {
+            [CompletionResult]::new('-i', 'i', [CompletionResultType]::ParameterName, 'Show information about torrent at `PATH`. If `Path` is `-`, read torrent metainfo from standard input.')
+            [CompletionResult]::new('--input', 'input', [CompletionResultType]::ParameterName, 'Show information about torrent at `PATH`. If `Path` is `-`, read torrent metainfo from standard input.')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help message.')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help message.')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version number.')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version number.')
+            break
+        }
+        'imdl;torrent;stats' {
+            [CompletionResult]::new('-l', 'l', [CompletionResultType]::ParameterName, 'Stop after processing `N` torrents. Useful when processing large collections of `.torrent` files.')
+            [CompletionResult]::new('--limit', 'limit', [CompletionResultType]::ParameterName, 'Stop after processing `N` torrents. Useful when processing large collections of `.torrent` files.')
+            [CompletionResult]::new('-e', 'e', [CompletionResultType]::ParameterName, 'Extract and display values under key paths that match `REGEX`. Subkeys of a bencodeded dictionary are delimited by `/`, and values of a bencoded list are delmited by `*`. For example, given the following bencoded dictionary `{"foo": [{"bar": {"baz": 2}}]}`, the value `2`''s key path will be `foo*bar/baz`. The value `2` would be displayed if any of `bar`, `foo[*]bar/baz`, or `foo.*baz` were passed to `--extract-pattern.')
+            [CompletionResult]::new('--extract-pattern', 'extract-pattern', [CompletionResultType]::ParameterName, 'Extract and display values under key paths that match `REGEX`. Subkeys of a bencodeded dictionary are delimited by `/`, and values of a bencoded list are delmited by `*`. For example, given the following bencoded dictionary `{"foo": [{"bar": {"baz": 2}}]}`, the value `2`''s key path will be `foo*bar/baz`. The value `2` would be displayed if any of `bar`, `foo[*]bar/baz`, or `foo.*baz` were passed to `--extract-pattern.')
+            [CompletionResult]::new('-i', 'i', [CompletionResultType]::ParameterName, 'Search `PATH` for torrents. May be a directory or a single torrent file.')
+            [CompletionResult]::new('--input', 'input', [CompletionResultType]::ParameterName, 'Search `PATH` for torrents. May be a directory or a single torrent file.')
+            [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'Pretty print the contents of each torrent as it is processed.')
+            [CompletionResult]::new('--print', 'print', [CompletionResultType]::ParameterName, 'Pretty print the contents of each torrent as it is processed.')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help message.')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help message.')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version number.')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version number.')
+            break
+        }
+        'imdl;torrent;verify' {
+            [CompletionResult]::new('-i', 'i', [CompletionResultType]::ParameterName, 'Verify torrent contents against torrent metainfo in `METAINFO`. If `METAINFO` is `-`, read metainfo from standard input.')
+            [CompletionResult]::new('--input', 'input', [CompletionResultType]::ParameterName, 'Verify torrent contents against torrent metainfo in `METAINFO`. If `METAINFO` is `-`, read metainfo from standard input.')
+            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'Verify torrent content at `PATH` against torrent metainfo. Defaults to `name` field of torrent info dictionary.')
+            [CompletionResult]::new('--content', 'content', [CompletionResultType]::ParameterName, 'Verify torrent content at `PATH` against torrent metainfo. Defaults to `name` field of torrent info dictionary.')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help message.')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help message.')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version number.')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version number.')
+            break
+        }
+        'imdl;torrent;help' {
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Prints help information')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Prints version information')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Prints version information')
+            break
+        }
+        'imdl;completions' {
+            [CompletionResult]::new('-s', 's', [CompletionResultType]::ParameterName, 'Print completions for `SHELL`.')
+            [CompletionResult]::new('--shell', 'shell', [CompletionResultType]::ParameterName, 'Print completions for `SHELL`.')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help message.')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help message.')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version number.')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version number.')
+            break
+        }
+        'imdl;help' {
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Prints help information')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Prints version information')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Prints version information')
+            break
+        }
+    })
+
+    $completions.Where{ $_.CompletionText -like "$wordToComplete*" } |
+        Sort-Object -Property ListItemText
+}

--- a/completions/imdl.zsh
+++ b/completions/imdl.zsh
@@ -1,0 +1,335 @@
+#compdef imdl
+
+autoload -U is-at-least
+
+_imdl() {
+    typeset -A opt_args
+    typeset -a _arguments_options
+    local ret=1
+
+    if is-at-least 5.2; then
+        _arguments_options=(-s -S -C)
+    else
+        _arguments_options=(-s -C)
+    fi
+
+    local context curcontext="$curcontext" state line
+    _arguments "${_arguments_options[@]}" \
+'--color=[Print colorful output according to `WHEN`. When `auto`, the default, colored output is only enabled if imdl detects that it is connected to a terminal, the `NO_COLOR` environment variable is not set, and the `TERM` environment variable is not set to `dumb`.]: :(auto always never)' \
+'-u[Enable unstable features. To avoid premature stabilization and excessive version churn, unstable features are unavailable unless this flag is set. Unstable features are not bound by semantic versioning stability guarantees, and may be changed or removed at any time.]' \
+'--unstable[Enable unstable features. To avoid premature stabilization and excessive version churn, unstable features are unavailable unless this flag is set. Unstable features are not bound by semantic versioning stability guarantees, and may be changed or removed at any time.]' \
+'-h[Print help message.]' \
+'--help[Print help message.]' \
+'-V[Print version number.]' \
+'--version[Print version number.]' \
+":: :_imdl_commands" \
+"*::: :->imdl" \
+&& ret=0
+    case $state in
+    (imdl)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:imdl-command-$line[1]:"
+        case $line[1] in
+            (torrent)
+_arguments "${_arguments_options[@]}" \
+'-h[Print help message.]' \
+'--help[Print help message.]' \
+'-V[Print version number.]' \
+'--version[Print version number.]' \
+":: :_imdl__torrent_commands" \
+"*::: :->torrent" \
+&& ret=0
+case $state in
+    (torrent)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:imdl-torrent-command-$line[1]:"
+        case $line[1] in
+            (create)
+_arguments "${_arguments_options[@]}" \
+'-a+[Use `URL` as the primary tracker announce URL. To supply multiple announce URLs, also use `--announce-tier`.]' \
+'--announce=[Use `URL` as the primary tracker announce URL. To supply multiple announce URLs, also use `--announce-tier`.]' \
+'*-A+[Allow `LINT`. Lints check for conditions which, although permitted, are not usually desirable. For example, piece length can be any non-zero value, but probably shouldn'\''t be below 16 KiB. The lint `small-piece-size` checks for this, and `--allow small-piece-size` can be used to disable this check.]: :(private-trackerless small-piece-length uneven-piece-length)' \
+'*--allow=[Allow `LINT`. Lints check for conditions which, although permitted, are not usually desirable. For example, piece length can be any non-zero value, but probably shouldn'\''t be below 16 KiB. The lint `small-piece-size` checks for this, and `--allow small-piece-size` can be used to disable this check.]: :(private-trackerless small-piece-length uneven-piece-length)' \
+'*-t+[Use `URL-LIST` as a tracker announce tier. Each instance adds a new tier. To add multiple trackers to a given tier, separate their announce URLs with commas:
+
+`--announce-tier udp://example.com:80/announce,https://example.net:443/announce`
+            
+Announce tiers are stored in the `announce-list` key of the top-level metainfo dictionary as a list of lists of strings, as defined by BEP 12: Multitracker Metadata Extension.
+            
+Note: Many BitTorrent clients do not implement the behavior described in BEP 12. See the discussion here for more details: https://github.com/bittorrent/bittorrent.org/issues/82]' \
+'*--announce-tier=[Use `URL-LIST` as a tracker announce tier. Each instance adds a new tier. To add multiple trackers to a given tier, separate their announce URLs with commas:
+
+`--announce-tier udp://example.com:80/announce,https://example.net:443/announce`
+            
+Announce tiers are stored in the `announce-list` key of the top-level metainfo dictionary as a list of lists of strings, as defined by BEP 12: Multitracker Metadata Extension.
+            
+Note: Many BitTorrent clients do not implement the behavior described in BEP 12. See the discussion here for more details: https://github.com/bittorrent/bittorrent.org/issues/82]' \
+'-c+[Include `TEXT` as the comment for generated `.torrent` file. Stored under `comment` key of top-level metainfo dictionary.]' \
+'--comment=[Include `TEXT` as the comment for generated `.torrent` file. Stored under `comment` key of top-level metainfo dictionary.]' \
+'*--node=[Add DHT bootstrap node `NODE` to torrent. `NODE` should be in the form `HOST:PORT`, where `HOST` is a domain name, an IPv4 address, or an IPv6 address surrounded by brackets. May be given more than once to add multiple bootstrap nodes.
+
+Examples:
+
+    --node router.example.com:1337
+
+    --node 203.0.113.0:2290
+
+    --node \[2001:db8:4275:7920:6269:7463:6f69:6e21\]:8832]' \
+'*-g+[Include or exclude files that match `GLOB`. Multiple glob may be provided, with the last one taking precedence. Precede a glob with `!` to exclude it.]' \
+'*--glob=[Include or exclude files that match `GLOB`. Multiple glob may be provided, with the last one taking precedence. Precede a glob with `!` to exclude it.]' \
+'-i+[Read torrent contents from `PATH`. If `PATH` is a file, torrent will be a single-file torrent, if `PATH` is a directory, torrent will be a multi-file torrent.]' \
+'--input=[Read torrent contents from `PATH`. If `PATH` is a file, torrent will be a single-file torrent, if `PATH` is a directory, torrent will be a multi-file torrent.]' \
+'-N+[Set name of torrent to `TEXT`. Defaults to the filename of the argument to `--input`.]' \
+'--name=[Set name of torrent to `TEXT`. Defaults to the filename of the argument to `--input`.]' \
+'*--sort-by=[Set the order of files within a torrent. `SPEC` should be of the form `KEY:ORDER`, with `KEY` being one of `path` or `size`, and `ORDER` being `ascending` or `descending`. `:ORDER` defaults to `ascending` if omitted. The `--sort-by` flag may be given more than once, with later values being used to break ties. Ties that remain are broken in ascending path order.
+
+Sort in ascending order by path, the default:
+
+    --sort-by path:ascending
+
+Sort in ascending order by path, more concisely:
+
+    --sort-by path
+
+Sort in ascending order by size, break ties in descending path order:
+
+    --sort-by size:ascending --sort-by path:descending]' \
+'-o+[Save `.torrent` file to `TARGET`, or print to standard output if `TARGET` is `-`. Defaults to `$INPUT.torrent`.]' \
+'--output=[Save `.torrent` file to `TARGET`, or print to standard output if `TARGET` is `-`. Defaults to `$INPUT.torrent`.]' \
+'*--peer=[Add `PEER` to magnet link.]' \
+'-p+[Set piece length to `BYTES`. Accepts SI units, e.g. kib, mib, and gib.]' \
+'--piece-length=[Set piece length to `BYTES`. Accepts SI units, e.g. kib, mib, and gib.]' \
+'-s+[Set torrent source to `TEXT`. Stored under `source` key of info dictionary. This is useful for keeping statistics from being mis-reported when participating in swarms with the same contents, but with different trackers. When source is set to a unique value for torrents with the same contents, torrent clients will treat them as distinct torrents, and not share peers between them, and will correctly report download and upload statistics to multiple trackers.]' \
+'--source=[Set torrent source to `TEXT`. Stored under `source` key of info dictionary. This is useful for keeping statistics from being mis-reported when participating in swarms with the same contents, but with different trackers. When source is set to a unique value for torrents with the same contents, torrent clients will treat them as distinct torrents, and not share peers between them, and will correctly report download and upload statistics to multiple trackers.]' \
+'-n[Skip writing `.torrent` file to disk.]' \
+'--dry-run[Skip writing `.torrent` file to disk.]' \
+'-F[Follow symlinks in torrent input. By default, symlinks to files and directories are not included in torrent contents.]' \
+'--follow-symlinks[Follow symlinks in torrent input. By default, symlinks to files and directories are not included in torrent contents.]' \
+'-f[Overwrite the destination `.torrent` file, if it exists.]' \
+'--force[Overwrite the destination `.torrent` file, if it exists.]' \
+'-h[Include hidden files that would otherwise be skipped, such as files that start with a `.`, and files hidden by file attributes on macOS and Windows.]' \
+'--include-hidden[Include hidden files that would otherwise be skipped, such as files that start with a `.`, and files hidden by file attributes on macOS and Windows.]' \
+'-j[Include junk files that would otherwise be skipped.]' \
+'--include-junk[Include junk files that would otherwise be skipped.]' \
+'--link[Print created torrent `magnet:` URL to standard output]' \
+'-M[Include MD5 checksum of each file in the torrent. N.B. MD5 is cryptographically broken and only suitable for checking for accidental corruption.]' \
+'--md5[Include MD5 checksum of each file in the torrent. N.B. MD5 is cryptographically broken and only suitable for checking for accidental corruption.]' \
+'--no-created-by[Do not populate `created by` key of generated torrent with imdl version information.]' \
+'--no-creation-date[Do not populate `creation date` key of generated torrent with current time.]' \
+'-O[Open `.torrent` file after creation. Uses `xdg-open`, `gnome-open`, or `kde-open` on Linux; `open` on macOS; and `cmd /C start` on Windows]' \
+'--open[Open `.torrent` file after creation. Uses `xdg-open`, `gnome-open`, or `kde-open` on Linux; `open` on macOS; and `cmd /C start` on Windows]' \
+'-P[Set the `private` flag. Torrent clients that understand the flag and participate in the swarm of a torrent with the flag set will only announce themselves to the announce URLs included in the torrent, and will not use other peer discovery mechanisms, such as the DHT or local peer discovery. See BEP 27: Private Torrents for more information.]' \
+'--private[Set the `private` flag. Torrent clients that understand the flag and participate in the swarm of a torrent with the flag set will only announce themselves to the announce URLs included in the torrent, and will not use other peer discovery mechanisms, such as the DHT or local peer discovery. See BEP 27: Private Torrents for more information.]' \
+'-S[Display information about created torrent file.]' \
+'--show[Display information about created torrent file.]' \
+'--help[Print help message.]' \
+'-V[Print version number.]' \
+'--version[Print version number.]' \
+&& ret=0
+;;
+(link)
+_arguments "${_arguments_options[@]}" \
+'-i+[Generate magnet link from metainfo at `PATH`. If `PATH` is `-`, read metainfo from standard input.]' \
+'--input=[Generate magnet link from metainfo at `PATH`. If `PATH` is `-`, read metainfo from standard input.]' \
+'*-p+[Add `PEER` to magnet link.]' \
+'*--peer=[Add `PEER` to magnet link.]' \
+'-O[Open generated magnet link. Uses `xdg-open`, `gnome-open`, or `kde-open` on Linux; `open` on macOS; and `cmd /C start` on Windows]' \
+'--open[Open generated magnet link. Uses `xdg-open`, `gnome-open`, or `kde-open` on Linux; `open` on macOS; and `cmd /C start` on Windows]' \
+'-h[Print help message.]' \
+'--help[Print help message.]' \
+'-V[Print version number.]' \
+'--version[Print version number.]' \
+&& ret=0
+;;
+(piece-size)
+_arguments "${_arguments_options[@]}" \
+'-h[Print help message.]' \
+'--help[Print help message.]' \
+'-V[Print version number.]' \
+'--version[Print version number.]' \
+&& ret=0
+;;
+(piece-length)
+_arguments "${_arguments_options[@]}" \
+'-h[Print help message.]' \
+'--help[Print help message.]' \
+'-V[Print version number.]' \
+'--version[Print version number.]' \
+&& ret=0
+;;
+(show)
+_arguments "${_arguments_options[@]}" \
+'-i+[Show information about torrent at `PATH`. If `Path` is `-`, read torrent metainfo from standard input.]' \
+'--input=[Show information about torrent at `PATH`. If `Path` is `-`, read torrent metainfo from standard input.]' \
+'-h[Print help message.]' \
+'--help[Print help message.]' \
+'-V[Print version number.]' \
+'--version[Print version number.]' \
+&& ret=0
+;;
+(stats)
+_arguments "${_arguments_options[@]}" \
+'-l+[Stop after processing `N` torrents. Useful when processing large collections of `.torrent` files.]' \
+'--limit=[Stop after processing `N` torrents. Useful when processing large collections of `.torrent` files.]' \
+'*-e+[Extract and display values under key paths that match `REGEX`. Subkeys of a bencodeded dictionary are delimited by `/`, and values of a bencoded list are delmited by `*`. For example, given the following bencoded dictionary `{"foo": \[{"bar": {"baz": 2}}\]}`, the value `2`'\''s key path will be `foo*bar/baz`. The value `2` would be displayed if any of `bar`, `foo\[*\]bar/baz`, or `foo.*baz` were passed to `--extract-pattern.]' \
+'*--extract-pattern=[Extract and display values under key paths that match `REGEX`. Subkeys of a bencodeded dictionary are delimited by `/`, and values of a bencoded list are delmited by `*`. For example, given the following bencoded dictionary `{"foo": \[{"bar": {"baz": 2}}\]}`, the value `2`'\''s key path will be `foo*bar/baz`. The value `2` would be displayed if any of `bar`, `foo\[*\]bar/baz`, or `foo.*baz` were passed to `--extract-pattern.]' \
+'-i+[Search `PATH` for torrents. May be a directory or a single torrent file.]' \
+'--input=[Search `PATH` for torrents. May be a directory or a single torrent file.]' \
+'-p[Pretty print the contents of each torrent as it is processed.]' \
+'--print[Pretty print the contents of each torrent as it is processed.]' \
+'-h[Print help message.]' \
+'--help[Print help message.]' \
+'-V[Print version number.]' \
+'--version[Print version number.]' \
+&& ret=0
+;;
+(verify)
+_arguments "${_arguments_options[@]}" \
+'-i+[Verify torrent contents against torrent metainfo in `METAINFO`. If `METAINFO` is `-`, read metainfo from standard input.]' \
+'--input=[Verify torrent contents against torrent metainfo in `METAINFO`. If `METAINFO` is `-`, read metainfo from standard input.]' \
+'-c+[Verify torrent content at `PATH` against torrent metainfo. Defaults to `name` field of torrent info dictionary.]' \
+'--content=[Verify torrent content at `PATH` against torrent metainfo. Defaults to `name` field of torrent info dictionary.]' \
+'-h[Print help message.]' \
+'--help[Print help message.]' \
+'-V[Print version number.]' \
+'--version[Print version number.]' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" \
+'-h[Prints help information]' \
+'--help[Prints help information]' \
+'-V[Prints version information]' \
+'--version[Prints version information]' \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
+(completions)
+_arguments "${_arguments_options[@]}" \
+'-s+[Print completions for `SHELL`.]: :(zsh bash fish powershell elvish)' \
+'--shell=[Print completions for `SHELL`.]: :(zsh bash fish powershell elvish)' \
+'-h[Print help message.]' \
+'--help[Print help message.]' \
+'-V[Print version number.]' \
+'--version[Print version number.]' \
+&& ret=0
+;;
+(help)
+_arguments "${_arguments_options[@]}" \
+'-h[Prints help information]' \
+'--help[Prints help information]' \
+'-V[Prints version information]' \
+'--version[Prints version information]' \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+}
+
+(( $+functions[_imdl_commands] )) ||
+_imdl_commands() {
+    local commands; commands=(
+        "torrent:Subcommands related to the BitTorrent protocol." \
+"completions:Print shell completion scripts to standard output." \
+"help:Prints this message or the help of the given subcommand(s)" \
+    )
+    _describe -t commands 'imdl commands' commands "$@"
+}
+(( $+functions[_imdl__completions_commands] )) ||
+_imdl__completions_commands() {
+    local commands; commands=(
+        
+    )
+    _describe -t commands 'imdl completions commands' commands "$@"
+}
+(( $+functions[_imdl__torrent__create_commands] )) ||
+_imdl__torrent__create_commands() {
+    local commands; commands=(
+        
+    )
+    _describe -t commands 'imdl torrent create commands' commands "$@"
+}
+(( $+functions[_imdl__help_commands] )) ||
+_imdl__help_commands() {
+    local commands; commands=(
+        
+    )
+    _describe -t commands 'imdl help commands' commands "$@"
+}
+(( $+functions[_imdl__torrent__help_commands] )) ||
+_imdl__torrent__help_commands() {
+    local commands; commands=(
+        
+    )
+    _describe -t commands 'imdl torrent help commands' commands "$@"
+}
+(( $+functions[_imdl__torrent__link_commands] )) ||
+_imdl__torrent__link_commands() {
+    local commands; commands=(
+        
+    )
+    _describe -t commands 'imdl torrent link commands' commands "$@"
+}
+(( $+functions[_imdl__torrent__piece-length_commands] )) ||
+_imdl__torrent__piece-length_commands() {
+    local commands; commands=(
+        
+    )
+    _describe -t commands 'imdl torrent piece-length commands' commands "$@"
+}
+(( $+functions[_imdl__piece-size_commands] )) ||
+_imdl__piece-size_commands() {
+    local commands; commands=(
+        
+    )
+    _describe -t commands 'imdl piece-size commands' commands "$@"
+}
+(( $+functions[_imdl__torrent__piece-size_commands] )) ||
+_imdl__torrent__piece-size_commands() {
+    local commands; commands=(
+        
+    )
+    _describe -t commands 'imdl torrent piece-size commands' commands "$@"
+}
+(( $+functions[_imdl__torrent__show_commands] )) ||
+_imdl__torrent__show_commands() {
+    local commands; commands=(
+        
+    )
+    _describe -t commands 'imdl torrent show commands' commands "$@"
+}
+(( $+functions[_imdl__torrent__stats_commands] )) ||
+_imdl__torrent__stats_commands() {
+    local commands; commands=(
+        
+    )
+    _describe -t commands 'imdl torrent stats commands' commands "$@"
+}
+(( $+functions[_imdl__torrent_commands] )) ||
+_imdl__torrent_commands() {
+    local commands; commands=(
+        "create:Create a `.torrent` file." \
+"link:Generate a magnet link from a `.torrent` file." \
+"piece-length:Display information about automatic piece length selection." \
+"show:Display information about a `.torrent` file." \
+"stats:Show statistics about a collection of `.torrent` files." \
+"verify:Verify files against a `.torrent` file." \
+"help:Prints this message or the help of the given subcommand(s)" \
+    )
+    _describe -t commands 'imdl torrent commands' commands "$@"
+}
+(( $+functions[_imdl__torrent__verify_commands] )) ||
+_imdl__torrent__verify_commands() {
+    local commands; commands=(
+        
+    )
+    _describe -t commands 'imdl torrent verify commands' commands "$@"
+}
+
+_imdl "$@"

--- a/justfile
+++ b/justfile
@@ -63,6 +63,9 @@ dev-deps:
 update-toc:
 	cargo run --package update-readme toc
 
+generate-completions:
+	./bin/generate-completions
+
 check-minimal-versions:
 	./bin/check-minimal-versions
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -10,7 +10,7 @@ pub(crate) use std::{
   fmt::{self, Display, Formatter},
   fs::{self, File},
   hash::Hash,
-  io::{self, Read, Write},
+  io::{self, Cursor, Read, Write},
   iter::{self, Sum},
   num::{ParseFloatError, ParseIntError, TryFromIntError},
   ops::{AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign},
@@ -64,8 +64,8 @@ pub(crate) use crate::{
   md5_digest::Md5Digest, metainfo::Metainfo, metainfo_error::MetainfoError, mode::Mode,
   options::Options, output_stream::OutputStream, output_target::OutputTarget,
   piece_length_picker::PieceLengthPicker, piece_list::PieceList, platform::Platform,
-  sha1_digest::Sha1Digest, sort_key::SortKey, sort_order::SortOrder, sort_spec::SortSpec,
-  status::Status, style::Style, subcommand::Subcommand, table::Table,
+  sha1_digest::Sha1Digest, shell::Shell, sort_key::SortKey, sort_order::SortOrder,
+  sort_spec::SortSpec, status::Status, style::Style, subcommand::Subcommand, table::Table,
   torrent_summary::TorrentSummary, use_color::UseColor, verifier::Verifier, walker::Walker,
 };
 
@@ -77,7 +77,6 @@ mod test {
   // test stdlib types
   pub(crate) use std::{
     cell::RefCell,
-    io::Cursor,
     ops::{Deref, DerefMut},
     process::Command,
     rc::Rc,

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,6 +86,7 @@ mod platform_interface;
 mod print;
 mod reckoner;
 mod sha1_digest;
+mod shell;
 mod sort_key;
 mod sort_order;
 mod sort_spec;

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,0 +1,35 @@
+use super::*;
+
+use structopt::clap;
+
+#[derive(EnumVariantNames, EnumString)]
+#[strum(serialize_all = "kebab-case")]
+pub(crate) enum Shell {
+  Zsh,
+  Bash,
+  Fish,
+  Powershell,
+  Elvish,
+}
+
+impl Into<clap::Shell> for Shell {
+  fn into(self) -> clap::Shell {
+    match self {
+      Self::Bash => clap::Shell::Bash,
+      Self::Fish => clap::Shell::Fish,
+      Self::Zsh => clap::Shell::Zsh,
+      Self::Powershell => clap::Shell::PowerShell,
+      Self::Elvish => clap::Shell::Elvish,
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn variants() {
+    assert_eq!(Shell::VARIANTS, clap::Shell::variants())
+  }
+}

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -1,16 +1,19 @@
 use crate::common::*;
 
+mod completions;
 mod torrent;
 
 #[derive(StructOpt)]
 pub(crate) enum Subcommand {
   Torrent(torrent::Torrent),
+  Completions(completions::Completions),
 }
 
 impl Subcommand {
   pub(crate) fn run(self, env: &mut Env, options: &Options) -> Result<(), Error> {
     match self {
       Self::Torrent(torrent) => torrent.run(env, options),
+      Self::Completions(completions) => completions.run(env),
     }
   }
 }

--- a/src/subcommand/completions.rs
+++ b/src/subcommand/completions.rs
@@ -1,0 +1,56 @@
+use crate::common::*;
+
+#[derive(StructOpt)]
+#[structopt(
+  help_message(consts::HELP_MESSAGE),
+  version_message(consts::VERSION_MESSAGE),
+  about("Print shell completion scripts to standard output.")
+)]
+pub(crate) struct Completions {
+  #[structopt(
+    long = "shell",
+    short = "s",
+    value_name = "SHELL",
+    possible_values = Shell::VARIANTS,
+    help = "Print completions for `SHELL`.",
+  )]
+  shell: Shell,
+}
+
+impl Completions {
+  pub(crate) fn run(self, env: &mut Env) -> Result<(), Error> {
+    let buffer = Vec::new();
+    let mut cursor = Cursor::new(buffer);
+
+    Arguments::clap().gen_completions_to(env!("CARGO_PKG_NAME"), self.shell.into(), &mut cursor);
+
+    let buffer = cursor.into_inner();
+
+    let script = String::from_utf8(buffer).expect("Clap completion not UTF-8");
+
+    outln!(env, "{}", script.trim())?;
+
+    Ok(())
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn output() {
+    let mut env = test_env! {
+      args: [
+        "completions",
+        "--shell",
+        "bash",
+      ],
+      tree: {},
+    };
+
+    assert_matches!(env.run(), Ok(()));
+
+    assert!(env.out().starts_with("_imdl() {"));
+  }
+}


### PR DESCRIPTION
Shell completion scripts can be generated for `bash`, `elvish`, `fish`,
`powershell`, and `zsh` with the `completions` subcommand:

    $ imdl completions --shell zsh > imdl.zsh

The same scripts are available in the `completions` directory. Please
refer to your shell's documentation for more information on how to
install and use completion scripts.

Fixes #295.