### PR TITLE
Cache build artifacts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,7 @@ on:
 jobs:
   all:
     name: All
+
     strategy:
       matrix:
         os:
@@ -26,11 +27,33 @@ jobs:
           target: x86_64-apple-darwin
         - os: windows-latest
           target: x86_64-pc-windows-msvc
+
     runs-on: ${{matrix.os}}
+
     env:
       RUSTFLAGS: "-D warnings"
+
     steps:
     - uses: actions/checkout@v2
+
+    - name: Cache cargo registry
+      uses: actions/cache@v1
+      with:
+        path: ~/.cargo/registry
+        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: Cache cargo index
+      uses: actions/cache@v1
+      with:
+        path: ~/.cargo/git
+        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: Cache cargo build
+      uses: actions/cache@v1
+      with:
+        path: target
+        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
     - name: Install Stable
       uses: actions-rs/toolchain@v1
       with:
@@ -39,20 +62,26 @@ jobs:
         profile: minimal
         components: clippy, rustfmt
         override: true
+
     - name: Version
       run: |
         rustup --version
         cargo --version
         cargo clippy --version
+
     - name: Build
       run: cargo build --all --verbose
+
     - name: Test
       run: cargo test --all --verbose
+
     - name: Clippy
       run: cargo clippy --all
+
     - name: Lint
       if: matrix.os != 'windows-latest'
       run: ./bin/lint
+
     - name: Install Nightly
       uses: actions-rs/toolchain@v1
       with:
@@ -60,27 +89,34 @@ jobs:
         target: ${{matrix.target}}
         profile: minimal
         components: rustfmt
+
     - name: Format
       run: cargo +nightly fmt --all -- --check
+
     - name: Completion Scripts
       if: matrix.os != 'windows-latest'
       run: |
         ./bin/generate-completions
         git diff --no-ext-diff --quiet --exit-code
+
     - name: Readme
       if: matrix.os != 'windows-latest'
       run: |
         cargo run --package update-readme toc
         git diff --no-ext-diff --quiet --exit-code
+
     - name: Install `mdbook`
       uses: peaceiris/actions-mdbook@v1
       with:
         mdbook-version: latest
+
     - name: Build Book
       run: mdbook build book --dest-dir ../www/book
+
     - name: Record Git Revision
       if: github.ref == 'refs/heads/master' && matrix.os == 'ubuntu-latest'
       run: git rev-parse --verify HEAD > www/head.txt
+
     - name: Deploy Pages
       uses: peaceiris/actions-gh-pages@v3
       if: github.ref == 'refs/heads/master' && matrix.os == 'ubuntu-latest'
@@ -88,11 +124,13 @@ jobs:
         github_token: ${{secrets.GITHUB_TOKEN}}
         publish_branch: gh-pages
         publish_dir: ./www
+
     - name: Package
       id: package
       if: startsWith(github.ref, 'refs/tags/v')
       shell: bash
       run: ./bin/package ${{github.ref}} ${{matrix.os}} ${{matrix.target}}
+
     - name: Publish
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
Use `actions/cache` to cache cargo registry, index, and build between
workflow runs.