### PR TITLE
[WIP] Add ability create torrents from STDIN

### DIFF
--- a/bin/generate-completions
+++ b/bin/generate-completions
@@ -2,7 +2,9 @@
 
 set -euxo pipefail
 
+cargo build
+
 for script in completions/*; do
   shell=${script##*.}
-  cargo run -- completions --shell $shell > $script
+  ./target/debug/imdl completions --shell $shell > $script
 done

--- a/completions/imdl.elvish
+++ b/completions/imdl.elvish
@@ -70,10 +70,10 @@ Examples:
     --node [2001:db8:4275:7920:6269:7463:6f69:6e21]:8832'
             cand -g 'Include or exclude files that match `GLOB`. Multiple glob may be provided, with the last one taking precedence. Precede a glob with `!` to exclude it.'
             cand --glob 'Include or exclude files that match `GLOB`. Multiple glob may be provided, with the last one taking precedence. Precede a glob with `!` to exclude it.'
-            cand -i 'Read torrent contents from `PATH`. If `PATH` is a file, torrent will be a single-file torrent, if `PATH` is a directory, torrent will be a multi-file torrent.'
-            cand --input 'Read torrent contents from `PATH`. If `PATH` is a file, torrent will be a single-file torrent, if `PATH` is a directory, torrent will be a multi-file torrent.'
-            cand -N 'Set name of torrent to `TEXT`. Defaults to the filename of the argument to `--input`.'
-            cand --name 'Set name of torrent to `TEXT`. Defaults to the filename of the argument to `--input`.'
+            cand -i 'Read torrent contents from `PATH`. If `PATH` is a file, torrent will be a single-file torrent.  If `PATH` is a directory, torrent will be a multi-file torrent.  If `PATH` is `-`, read from standard input. Piece length defaults to 256KiB when reading from standard input if `--piece-length` is not given.'
+            cand --input 'Read torrent contents from `PATH`. If `PATH` is a file, torrent will be a single-file torrent.  If `PATH` is a directory, torrent will be a multi-file torrent.  If `PATH` is `-`, read from standard input. Piece length defaults to 256KiB when reading from standard input if `--piece-length` is not given.'
+            cand -N 'Set name of torrent to `TEXT`. Defaults to the filename of the argument to `--input`. Required when `--input -`.'
+            cand --name 'Set name of torrent to `TEXT`. Defaults to the filename of the argument to `--input`. Required when `--input -`.'
             cand --sort-by 'Set the order of files within a torrent. `SPEC` should be of the form `KEY:ORDER`, with `KEY` being one of `path` or `size`, and `ORDER` being `ascending` or `descending`. `:ORDER` defaults to `ascending` if omitted. The `--sort-by` flag may be given more than once, with later values being used to break ties. Ties that remain are broken in ascending path order.
 
 Sort in ascending order by path, the default:
@@ -87,8 +87,8 @@ Sort in ascending order by path, more concisely:
 Sort in ascending order by size, break ties in descending path order:
 
     --sort-by size:ascending --sort-by path:descending'
-            cand -o 'Save `.torrent` file to `TARGET`, or print to standard output if `TARGET` is `-`. Defaults to `$INPUT.torrent`.'
-            cand --output 'Save `.torrent` file to `TARGET`, or print to standard output if `TARGET` is `-`. Defaults to `$INPUT.torrent`.'
+            cand -o 'Save `.torrent` file to `TARGET`, or print to standard output if `TARGET` is `-`. Defaults to the argument to `--input` with an `.torrent` extension appended. Required when `--input -`.'
+            cand --output 'Save `.torrent` file to `TARGET`, or print to standard output if `TARGET` is `-`. Defaults to the argument to `--input` with an `.torrent` extension appended. Required when `--input -`.'
             cand --peer 'Add `PEER` to magnet link.'
             cand -p 'Set piece length to `BYTES`. Accepts SI units, e.g. kib, mib, and gib.'
             cand --piece-length 'Set piece length to `BYTES`. Accepts SI units, e.g. kib, mib, and gib.'

--- a/completions/imdl.fish
+++ b/completions/imdl.fish
@@ -34,8 +34,8 @@ Examples:
 
     --node [2001:db8:4275:7920:6269:7463:6f69:6e21]:8832'
 complete -c imdl -n "__fish_seen_subcommand_from create" -s g -l glob -d 'Include or exclude files that match `GLOB`. Multiple glob may be provided, with the last one taking precedence. Precede a glob with `!` to exclude it.'
-complete -c imdl -n "__fish_seen_subcommand_from create" -s i -l input -d 'Read torrent contents from `PATH`. If `PATH` is a file, torrent will be a single-file torrent, if `PATH` is a directory, torrent will be a multi-file torrent.'
-complete -c imdl -n "__fish_seen_subcommand_from create" -s N -l name -d 'Set name of torrent to `TEXT`. Defaults to the filename of the argument to `--input`.'
+complete -c imdl -n "__fish_seen_subcommand_from create" -s i -l input -d 'Read torrent contents from `PATH`. If `PATH` is a file, torrent will be a single-file torrent.  If `PATH` is a directory, torrent will be a multi-file torrent.  If `PATH` is `-`, read from standard input. Piece length defaults to 256KiB when reading from standard input if `--piece-length` is not given.'
+complete -c imdl -n "__fish_seen_subcommand_from create" -s N -l name -d 'Set name of torrent to `TEXT`. Defaults to the filename of the argument to `--input`. Required when `--input -`.'
 complete -c imdl -n "__fish_seen_subcommand_from create" -l sort-by -d 'Set the order of files within a torrent. `SPEC` should be of the form `KEY:ORDER`, with `KEY` being one of `path` or `size`, and `ORDER` being `ascending` or `descending`. `:ORDER` defaults to `ascending` if omitted. The `--sort-by` flag may be given more than once, with later values being used to break ties. Ties that remain are broken in ascending path order.
 
 Sort in ascending order by path, the default:
@@ -49,7 +49,7 @@ Sort in ascending order by path, more concisely:
 Sort in ascending order by size, break ties in descending path order:
 
     --sort-by size:ascending --sort-by path:descending'
-complete -c imdl -n "__fish_seen_subcommand_from create" -s o -l output -d 'Save `.torrent` file to `TARGET`, or print to standard output if `TARGET` is `-`. Defaults to `$INPUT.torrent`.'
+complete -c imdl -n "__fish_seen_subcommand_from create" -s o -l output -d 'Save `.torrent` file to `TARGET`, or print to standard output if `TARGET` is `-`. Defaults to the argument to `--input` with an `.torrent` extension appended. Required when `--input -`.'
 complete -c imdl -n "__fish_seen_subcommand_from create" -l peer -d 'Add `PEER` to magnet link.'
 complete -c imdl -n "__fish_seen_subcommand_from create" -s p -l piece-length -d 'Set piece length to `BYTES`. Accepts SI units, e.g. kib, mib, and gib.'
 complete -c imdl -n "__fish_seen_subcommand_from create" -s s -l source -d 'Set torrent source to `TEXT`. Stored under `source` key of info dictionary. This is useful for keeping statistics from being mis-reported when participating in swarms with the same contents, but with different trackers. When source is set to a unique value for torrents with the same contents, torrent clients will treat them as distinct torrents, and not share peers between them, and will correctly report download and upload statistics to multiple trackers.'

--- a/completions/imdl.powershell
+++ b/completions/imdl.powershell
@@ -77,10 +77,10 @@ Examples:
     --node [2001:db8:4275:7920:6269:7463:6f69:6e21]:8832')
             [CompletionResult]::new('-g', 'g', [CompletionResultType]::ParameterName, 'Include or exclude files that match `GLOB`. Multiple glob may be provided, with the last one taking precedence. Precede a glob with `!` to exclude it.')
             [CompletionResult]::new('--glob', 'glob', [CompletionResultType]::ParameterName, 'Include or exclude files that match `GLOB`. Multiple glob may be provided, with the last one taking precedence. Precede a glob with `!` to exclude it.')
-            [CompletionResult]::new('-i', 'i', [CompletionResultType]::ParameterName, 'Read torrent contents from `PATH`. If `PATH` is a file, torrent will be a single-file torrent, if `PATH` is a directory, torrent will be a multi-file torrent.')
-            [CompletionResult]::new('--input', 'input', [CompletionResultType]::ParameterName, 'Read torrent contents from `PATH`. If `PATH` is a file, torrent will be a single-file torrent, if `PATH` is a directory, torrent will be a multi-file torrent.')
-            [CompletionResult]::new('-N', 'N', [CompletionResultType]::ParameterName, 'Set name of torrent to `TEXT`. Defaults to the filename of the argument to `--input`.')
-            [CompletionResult]::new('--name', 'name', [CompletionResultType]::ParameterName, 'Set name of torrent to `TEXT`. Defaults to the filename of the argument to `--input`.')
+            [CompletionResult]::new('-i', 'i', [CompletionResultType]::ParameterName, 'Read torrent contents from `PATH`. If `PATH` is a file, torrent will be a single-file torrent.  If `PATH` is a directory, torrent will be a multi-file torrent.  If `PATH` is `-`, read from standard input. Piece length defaults to 256KiB when reading from standard input if `--piece-length` is not given.')
+            [CompletionResult]::new('--input', 'input', [CompletionResultType]::ParameterName, 'Read torrent contents from `PATH`. If `PATH` is a file, torrent will be a single-file torrent.  If `PATH` is a directory, torrent will be a multi-file torrent.  If `PATH` is `-`, read from standard input. Piece length defaults to 256KiB when reading from standard input if `--piece-length` is not given.')
+            [CompletionResult]::new('-N', 'N', [CompletionResultType]::ParameterName, 'Set name of torrent to `TEXT`. Defaults to the filename of the argument to `--input`. Required when `--input -`.')
+            [CompletionResult]::new('--name', 'name', [CompletionResultType]::ParameterName, 'Set name of torrent to `TEXT`. Defaults to the filename of the argument to `--input`. Required when `--input -`.')
             [CompletionResult]::new('--sort-by', 'sort-by', [CompletionResultType]::ParameterName, 'Set the order of files within a torrent. `SPEC` should be of the form `KEY:ORDER`, with `KEY` being one of `path` or `size`, and `ORDER` being `ascending` or `descending`. `:ORDER` defaults to `ascending` if omitted. The `--sort-by` flag may be given more than once, with later values being used to break ties. Ties that remain are broken in ascending path order.
 
 Sort in ascending order by path, the default:
@@ -94,8 +94,8 @@ Sort in ascending order by path, more concisely:
 Sort in ascending order by size, break ties in descending path order:
 
     --sort-by size:ascending --sort-by path:descending')
-            [CompletionResult]::new('-o', 'o', [CompletionResultType]::ParameterName, 'Save `.torrent` file to `TARGET`, or print to standard output if `TARGET` is `-`. Defaults to `$INPUT.torrent`.')
-            [CompletionResult]::new('--output', 'output', [CompletionResultType]::ParameterName, 'Save `.torrent` file to `TARGET`, or print to standard output if `TARGET` is `-`. Defaults to `$INPUT.torrent`.')
+            [CompletionResult]::new('-o', 'o', [CompletionResultType]::ParameterName, 'Save `.torrent` file to `TARGET`, or print to standard output if `TARGET` is `-`. Defaults to the argument to `--input` with an `.torrent` extension appended. Required when `--input -`.')
+            [CompletionResult]::new('--output', 'output', [CompletionResultType]::ParameterName, 'Save `.torrent` file to `TARGET`, or print to standard output if `TARGET` is `-`. Defaults to the argument to `--input` with an `.torrent` extension appended. Required when `--input -`.')
             [CompletionResult]::new('--peer', 'peer', [CompletionResultType]::ParameterName, 'Add `PEER` to magnet link.')
             [CompletionResult]::new('-p', 'p', [CompletionResultType]::ParameterName, 'Set piece length to `BYTES`. Accepts SI units, e.g. kib, mib, and gib.')
             [CompletionResult]::new('--piece-length', 'piece-length', [CompletionResultType]::ParameterName, 'Set piece length to `BYTES`. Accepts SI units, e.g. kib, mib, and gib.')

--- a/completions/imdl.zsh
+++ b/completions/imdl.zsh
@@ -79,10 +79,10 @@ Examples:
     --node \[2001:db8:4275:7920:6269:7463:6f69:6e21\]:8832]' \
 '*-g+[Include or exclude files that match `GLOB`. Multiple glob may be provided, with the last one taking precedence. Precede a glob with `!` to exclude it.]' \
 '*--glob=[Include or exclude files that match `GLOB`. Multiple glob may be provided, with the last one taking precedence. Precede a glob with `!` to exclude it.]' \
-'-i+[Read torrent contents from `PATH`. If `PATH` is a file, torrent will be a single-file torrent, if `PATH` is a directory, torrent will be a multi-file torrent.]' \
-'--input=[Read torrent contents from `PATH`. If `PATH` is a file, torrent will be a single-file torrent, if `PATH` is a directory, torrent will be a multi-file torrent.]' \
-'-N+[Set name of torrent to `TEXT`. Defaults to the filename of the argument to `--input`.]' \
-'--name=[Set name of torrent to `TEXT`. Defaults to the filename of the argument to `--input`.]' \
+'-i+[Read torrent contents from `PATH`. If `PATH` is a file, torrent will be a single-file torrent.  If `PATH` is a directory, torrent will be a multi-file torrent.  If `PATH` is `-`, read from standard input. Piece length defaults to 256KiB when reading from standard input if `--piece-length` is not given.]' \
+'--input=[Read torrent contents from `PATH`. If `PATH` is a file, torrent will be a single-file torrent.  If `PATH` is a directory, torrent will be a multi-file torrent.  If `PATH` is `-`, read from standard input. Piece length defaults to 256KiB when reading from standard input if `--piece-length` is not given.]' \
+'-N+[Set name of torrent to `TEXT`. Defaults to the filename of the argument to `--input`. Required when `--input -`.]' \
+'--name=[Set name of torrent to `TEXT`. Defaults to the filename of the argument to `--input`. Required when `--input -`.]' \
 '*--sort-by=[Set the order of files within a torrent. `SPEC` should be of the form `KEY:ORDER`, with `KEY` being one of `path` or `size`, and `ORDER` being `ascending` or `descending`. `:ORDER` defaults to `ascending` if omitted. The `--sort-by` flag may be given more than once, with later values being used to break ties. Ties that remain are broken in ascending path order.
 
 Sort in ascending order by path, the default:
@@ -96,8 +96,8 @@ Sort in ascending order by path, more concisely:
 Sort in ascending order by size, break ties in descending path order:
 
     --sort-by size:ascending --sort-by path:descending]' \
-'-o+[Save `.torrent` file to `TARGET`, or print to standard output if `TARGET` is `-`. Defaults to `$INPUT.torrent`.]' \
-'--output=[Save `.torrent` file to `TARGET`, or print to standard output if `TARGET` is `-`. Defaults to `$INPUT.torrent`.]' \
+'-o+[Save `.torrent` file to `TARGET`, or print to standard output if `TARGET` is `-`. Defaults to the argument to `--input` with an `.torrent` extension appended. Required when `--input -`.]' \
+'--output=[Save `.torrent` file to `TARGET`, or print to standard output if `TARGET` is `-`. Defaults to the argument to `--input` with an `.torrent` extension appended. Required when `--input -`.]' \
 '*--peer=[Add `PEER` to magnet link.]' \
 '-p+[Set piece length to `BYTES`. Accepts SI units, e.g. kib, mib, and gib.]' \
 '--piece-length=[Set piece length to `BYTES`. Accepts SI units, e.g. kib, mib, and gib.]' \

--- a/src/common.rs
+++ b/src/common.rs
@@ -10,7 +10,7 @@ pub(crate) use std::{
   fmt::{self, Display, Formatter},
   fs::{self, File},
   hash::Hash,
-  io::{self, Cursor, Read, Write},
+  io::{self, BufRead, BufReader, Cursor, Read, Write},
   iter::{self, Sum},
   num::{ParseFloatError, ParseIntError, TryFromIntError},
   ops::{AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign},
@@ -35,7 +35,10 @@ pub(crate) use serde_with::rust::unwrap_or_skip;
 pub(crate) use sha1::Sha1;
 pub(crate) use snafu::{ResultExt, Snafu};
 pub(crate) use static_assertions::const_assert;
-pub(crate) use structopt::{clap::AppSettings, StructOpt};
+pub(crate) use structopt::{
+  clap::{self, AppSettings},
+  StructOpt,
+};
 pub(crate) use strum::VariantNames;
 pub(crate) use strum_macros::{EnumString, EnumVariantNames, IntoStaticStr};
 pub(crate) use unicode_width::UnicodeWidthStr;
@@ -51,7 +54,7 @@ pub(crate) use crate::{consts, error, host_port_parse_error};
 
 // traits
 pub(crate) use crate::{
-  into_u64::IntoU64, into_usize::IntoUsize, path_ext::PathExt,
+  input_stream::InputStream, into_u64::IntoU64, into_usize::IntoUsize, path_ext::PathExt,
   platform_interface::PlatformInterface, print::Print, reckoner::Reckoner, step::Step,
 };
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,5 @@
 use crate::common::*;
 
-use structopt::clap;
-
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
 pub(crate) enum Error {

--- a/src/input.rs
+++ b/src/input.rs
@@ -22,7 +22,7 @@ impl Input {
   pub(crate) fn from_path(path: &Path) -> Result<Input> {
     let data = fs::read(path).context(error::Filesystem { path })?;
     Ok(Input {
-      source: InputTarget::File(path.to_owned()),
+      source: InputTarget::Path(path.to_owned()),
       data,
     })
   }

--- a/src/input_stream.rs
+++ b/src/input_stream.rs
@@ -1,0 +1,23 @@
+use crate::common::*;
+
+pub(crate) trait InputStream {
+  fn buf_read<'a>(&'a mut self) -> Box<dyn BufRead + 'a>;
+}
+
+impl InputStream for io::Stdin {
+  fn buf_read<'a>(&'a mut self) -> Box<dyn BufRead + 'a> {
+    Box::new(self.lock())
+  }
+}
+
+impl InputStream for io::Empty {
+  fn buf_read<'a>(&'a mut self) -> Box<dyn BufRead + 'a> {
+    Box::new(BufReader::new(self))
+  }
+}
+
+impl InputStream for Cursor<Vec<u8>> {
+  fn buf_read<'a>(&'a mut self) -> Box<dyn BufRead + 'a> {
+    Box::new(BufReader::new(self))
+  }
+}

--- a/src/input_target.rs
+++ b/src/input_target.rs
@@ -2,8 +2,17 @@ use crate::common::*;
 
 #[derive(PartialEq, Debug, Clone)]
 pub(crate) enum InputTarget {
-  File(PathBuf),
+  Path(PathBuf),
   Stdin,
+}
+
+impl InputTarget {
+  pub(crate) fn resolve(&self, env: &Env) -> Self {
+    match self {
+      Self::Path(path) => Self::Path(env.resolve(path)),
+      Self::Stdin => Self::Stdin,
+    }
+  }
 }
 
 impl From<&OsStr> for InputTarget {
@@ -11,7 +20,7 @@ impl From<&OsStr> for InputTarget {
     if text == OsStr::new("-") {
       Self::Stdin
     } else {
-      Self::File(text.into())
+      Self::Path(text.into())
     }
   }
 }
@@ -20,16 +29,15 @@ impl Display for InputTarget {
   fn fmt(&self, f: &mut Formatter) -> fmt::Result {
     match self {
       Self::Stdin => write!(f, "standard input"),
-      Self::File(path) => write!(f, "`{}`", path.display()),
+      Self::Path(path) => write!(f, "`{}`", path.display()),
     }
   }
 }
 
-#[cfg(test)]
 impl<P: AsRef<Path>> PartialEq<P> for InputTarget {
   fn eq(&self, other: &P) -> bool {
     match self {
-      Self::File(path) => path == other.as_ref(),
+      Self::Path(path) => path == other.as_ref(),
       Self::Stdin => Path::new("-") == other.as_ref(),
     }
   }
@@ -43,7 +51,7 @@ mod tests {
   fn file() {
     assert_eq!(
       InputTarget::from(OsStr::new("foo")),
-      InputTarget::File("foo".into())
+      InputTarget::Path("foo".into())
     );
   }
 
@@ -55,7 +63,7 @@ mod tests {
   #[test]
   fn display_file() {
     let path = PathBuf::from("./path");
-    let have = InputTarget::File(path).to_string();
+    let have = InputTarget::Path(path).to_string();
     let want = "`./path`";
     assert_eq!(have, want);
   }

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,7 @@ mod host_port_parse_error;
 mod info;
 mod infohash;
 mod input;
+mod input_stream;
 mod input_target;
 mod into_u64;
 mod into_usize;

--- a/src/metainfo.rs
+++ b/src/metainfo.rs
@@ -76,7 +76,7 @@ impl Metainfo {
 
   #[cfg(test)]
   pub(crate) fn from_bytes(bytes: &[u8]) -> Metainfo {
-    Self::deserialize(&InputTarget::File("<TEST>".into()), bytes).unwrap()
+    Self::deserialize(&InputTarget::Path("<TEST>".into()), bytes).unwrap()
   }
 
   #[cfg(test)]

--- a/src/subcommand/torrent/verify.rs
+++ b/src/subcommand/torrent/verify.rs
@@ -45,7 +45,7 @@ impl Verify {
       content.clone()
     } else {
       match &self.metainfo {
-        InputTarget::File(path) => path.parent().unwrap().join(&metainfo.info.name),
+        InputTarget::Path(path) => path.parent().unwrap().join(&metainfo.info.name),
         InputTarget::Stdin => PathBuf::from(&metainfo.info.name),
       }
     };

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -77,6 +77,18 @@ impl TestEnv {
     fs::set_permissions(self.env.resolve(path), permissions).unwrap();
   }
 
+  pub(crate) fn assert_ok(&mut self) {
+    match self.run() {
+      Ok(()) => {}
+      Err(err) => {
+        eprintln!("Run failed: {}", err);
+        eprintln!("Std error:\n{}", self.err());
+        eprintln!("Std output:\n{}", self.out());
+        panic!();
+      }
+    }
+  }
+
   pub(crate) fn load_metainfo(&mut self, filename: impl AsRef<Path>) -> Metainfo {
     let input = self.env.read(filename.as_ref().as_os_str().into()).unwrap();
     Metainfo::from_input(&input).unwrap()

--- a/src/test_env_builder.rs
+++ b/src/test_env_builder.rs
@@ -4,7 +4,7 @@ pub(crate) struct TestEnvBuilder {
   args: Vec<OsString>,
   current_dir: Option<PathBuf>,
   err_style: bool,
-  input: Option<Box<dyn Read>>,
+  input: Option<Box<dyn InputStream>>,
   out_is_term: bool,
   tempdir: Option<TempDir>,
   use_color: bool,


### PR DESCRIPTION
WIP:

Recreating the pull request after the repo GPG signing.

`create --input -` now will use STDIN to generate a single file torrent.  The code is more or less complete, but some of the tests are hanging.  Also, the structure of the code isn't ideal.  The `Files`, `Hasher`, and other types all assume a `Pathbuf` object which definitely doesn't work for STDIN.  Definitely open for suggestions as I definitely forced the code into compilation without understanding everything (`dyn`, `box`, ...) 

- [x] Test torrent created from `-` is correct
- [x] Test that `--name` and `--output` are required when `--input -`
- [x] Improve speed of reading

fixes #261 