### PR TITLE
Add "Metadata/Prior Art" section to book

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -8,3 +8,6 @@ Summary
   - [Alternatives & Prior Art](./bittorrent/prior-art.md)
   - [UDP Tracker Protocol](./bittorrent/udp-tracker-protocol.md)
   - [References](./bittorrent/references.md)
+
+- [Metadata](./metadata.md)
+  - [Prior Art](./metadata/prior-art.md)

--- a/book/src/metadata.md
+++ b/book/src/metadata.md
@@ -1,0 +1,4 @@
+Metadata
+==========
+
+This page intentionally left blank.

--- a/book/src/metadata/prior-art.md
+++ b/book/src/metadata/prior-art.md
@@ -1,0 +1,4 @@
+Prior Art
+=========
+
+- [Media RSS Specification](http://www.rssboard.org/media-rss): _Media RSS is a new RSS module that supplements the <enclosure> capabilities of RSS 2.0. RSS enclosures are already being used to syndicate audio files and images. Media RSS extends enclosures to handle other media types, such as short films or TV, as well as provide additional metadata with the media. Media RSS enables content publishers and bloggers to syndicate multimedia content such as TV and video clips, movies, images and audio._


### PR DESCRIPTION
Mention Media RSS specification, a structured metadata standard for RSS.