### PR TITLE
Forbid empty input, output, and path targets

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -10,7 +10,6 @@ merge_imports               = true
 newline_style               = "Unix"
 normalize_comments          = true
 reorder_impl_items          = true
-required_version            = "1.4.12"
 tab_spaces                  = 2
 unstable_features           = true
 use_field_init_shorthand    = true

--- a/src/common.rs
+++ b/src/common.rs
@@ -4,7 +4,7 @@ pub(crate) use std::{
   char,
   cmp::{Ordering, Reverse},
   collections::{BTreeMap, BTreeSet, HashMap, HashSet},
-  convert::TryInto,
+  convert::{TryFrom, TryInto},
   env,
   ffi::{OsStr, OsString},
   fmt::{self, Display, Formatter},

--- a/src/env.rs
+++ b/src/env.rs
@@ -163,14 +163,20 @@ impl Env {
     &mut self.out
   }
 
-  pub(crate) fn resolve(&self, path: impl AsRef<Path>) -> PathBuf {
-    self.dir().join(path).clean()
+  pub(crate) fn resolve(&self, path: impl AsRef<Path>) -> Result<PathBuf> {
+    let path = path.as_ref();
+
+    if path.components().count() == 0 {
+      return Err(Error::internal("Empty path passed to resolve"));
+    }
+
+    Ok(self.dir().join(path).clean())
   }
 
   pub(crate) fn read(&mut self, source: InputTarget) -> Result<Input> {
     let data = match &source {
       InputTarget::Path(path) => {
-        let absolute = self.resolve(path);
+        let absolute = self.resolve(path)?;
         fs::read(absolute).context(error::Filesystem { path })?
       }
       InputTarget::Stdin => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,6 +30,8 @@ pub(crate) enum Error {
   GlobParse { source: globset::Error },
   #[snafu(display("Failed to serialize torrent info dictionary: {}", source))]
   InfoSerialize { source: bendy::serde::Error },
+  #[snafu(display("Input target empty"))]
+  InputTargetEmpty,
   #[snafu(display(
     "Interal error, this may indicate a bug in intermodal: {}\n\
      Consider filing an issue: https://github.com/casey/imdl/issues/new",
@@ -61,6 +63,8 @@ pub(crate) enum Error {
   OpenerExitStatus { exit_status: ExitStatus },
   #[snafu(display("Output path already exists: `{}`", path.display()))]
   OutputExists { path: PathBuf },
+  #[snafu(display("Output target empty"))]
+  OutputTargetEmpty,
   #[snafu(display(
     "Path `{}` contains non-normal component: {}",
     path.display(),

--- a/src/subcommand/torrent/link.rs
+++ b/src/subcommand/torrent/link.rs
@@ -11,9 +11,10 @@ pub(crate) struct Link {
     long = "input",
     short = "i",
     value_name = "METAINFO",
+    empty_values(false),
+    parse(try_from_os_str = InputTarget::try_from_os_str),
     help = "Generate magnet link from metainfo at `PATH`. If `PATH` is `-`, read metainfo from \
             standard input.",
-    parse(from_os_str)
   )]
   input: InputTarget,
   #[structopt(

--- a/src/subcommand/torrent/show.rs
+++ b/src/subcommand/torrent/show.rs
@@ -11,9 +11,10 @@ pub(crate) struct Show {
     long = "input",
     short = "i",
     value_name = "PATH",
+    empty_values(false),
+    parse(try_from_os_str = InputTarget::try_from_os_str),
     help = "Show information about torrent at `PATH`. If `Path` is `-`, read torrent metainfo \
             from standard input.",
-    parse(from_os_str)
   )]
   input: InputTarget,
 }
@@ -34,7 +35,7 @@ mod tests {
   use pretty_assertions::assert_eq;
 
   #[test]
-  fn output() {
+  fn output() -> Result<()> {
     let metainfo = Metainfo {
       announce: Some("announce".into()),
       announce_list: Some(vec![vec!["announce".into(), "b".into()], vec!["c".into()]]),
@@ -66,7 +67,7 @@ mod tests {
         .out_is_term()
         .build();
 
-      let path = env.resolve("foo.torrent");
+      let path = env.resolve("foo.torrent")?;
 
       metainfo.dump(path).unwrap();
 
@@ -103,7 +104,7 @@ Announce List  Tier 1: announce
         .arg_slice(&["imdl", "torrent", "show", "--input", "foo.torrent"])
         .build();
 
-      let path = env.resolve("foo.torrent");
+      let path = env.resolve("foo.torrent")?;
 
       metainfo.dump(path).unwrap();
 
@@ -131,10 +132,12 @@ files\tfoo
 
       assert_eq!(have, want);
     }
+
+    Ok(())
   }
 
   #[test]
-  fn tier_list_with_main() {
+  fn tier_list_with_main() -> Result<()> {
     let metainfo = Metainfo {
       announce: Some("a".into()),
       announce_list: Some(vec![vec!["x".into()], vec!["y".into()], vec!["z".into()]]),
@@ -166,7 +169,7 @@ files\tfoo
         .out_is_term()
         .build();
 
-      let path = env.resolve("foo.torrent");
+      let path = env.resolve("foo.torrent")?;
 
       metainfo.dump(path).unwrap();
 
@@ -203,7 +206,7 @@ Announce List  Tier 1: x
         .arg_slice(&["imdl", "torrent", "show", "--input", "foo.torrent"])
         .build();
 
-      let path = env.resolve("foo.torrent");
+      let path = env.resolve("foo.torrent")?;
 
       metainfo.dump(path).unwrap();
 
@@ -231,10 +234,12 @@ files\tfoo
 
       assert_eq!(have, want);
     }
+
+    Ok(())
   }
 
   #[test]
-  fn tier_list_without_main() {
+  fn tier_list_without_main() -> Result<()> {
     let metainfo = Metainfo {
       announce: Some("a".into()),
       announce_list: Some(vec![vec!["b".into()], vec!["c".into()], vec!["a".into()]]),
@@ -266,7 +271,7 @@ files\tfoo
         .out_is_term()
         .build();
 
-      let path = env.resolve("foo.torrent");
+      let path = env.resolve("foo.torrent")?;
 
       metainfo.dump(path).unwrap();
 
@@ -303,7 +308,7 @@ Announce List  Tier 1: b
         .arg_slice(&["imdl", "torrent", "show", "--input", "foo.torrent"])
         .build();
 
-      let path = env.resolve("foo.torrent");
+      let path = env.resolve("foo.torrent")?;
 
       metainfo.dump(path).unwrap();
 
@@ -331,10 +336,12 @@ files\tfoo
 
       assert_eq!(have, want);
     }
+
+    Ok(())
   }
 
   #[test]
-  fn trackerless() {
+  fn trackerless() -> Result<()> {
     let metainfo = Metainfo {
       announce: None,
       announce_list: None,
@@ -366,7 +373,7 @@ files\tfoo
         .out_is_term()
         .build();
 
-      let path = env.resolve("foo.torrent");
+      let path = env.resolve("foo.torrent")?;
 
       metainfo.dump(path).unwrap();
 
@@ -399,7 +406,7 @@ Creation Date  1970-01-01 00:00:01 UTC
         .arg_slice(&["imdl", "torrent", "show", "--input", "foo.torrent"])
         .build();
 
-      let path = env.resolve("foo.torrent");
+      let path = env.resolve("foo.torrent")?;
 
       metainfo.dump(path).unwrap();
 
@@ -425,5 +432,7 @@ files\tfoo
 
       assert_eq!(have, want);
     }
+
+    Ok(())
   }
 }

--- a/src/subcommand/torrent/stats.rs
+++ b/src/subcommand/torrent/stats.rs
@@ -19,6 +19,7 @@ pub(crate) struct Stats {
     long = "extract-pattern",
     short = "e",
     value_name = "REGEX",
+    empty_values(false),
     help = "Extract and display values under key paths that match `REGEX`. Subkeys of a \
             bencodeded dictionary are delimited by `/`, and values of a bencoded list are \
             delmited by `*`. For example, given the following bencoded dictionary `{\"foo\": \
@@ -31,8 +32,9 @@ pub(crate) struct Stats {
     long = "input",
     short = "i",
     value_name = "PATH",
-    help = "Search `PATH` for torrents. May be a directory or a single torrent file.",
-    parse(from_os_str)
+    empty_values(false),
+    parse(from_os_str),
+    help = "Search `PATH` for torrents. May be a directory or a single torrent file."
   )]
   input: PathBuf,
   #[structopt(
@@ -47,7 +49,7 @@ impl Stats {
   pub(crate) fn run(self, env: &mut Env, options: &Options) -> Result<(), Error> {
     options.require_unstable("torrent stats subcommand")?;
 
-    let path = env.resolve(self.input);
+    let path = env.resolve(self.input)?;
 
     let mut extractor = Extractor::new(self.print, &self.extract_patterns);
 

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -56,25 +56,25 @@ impl TestEnv {
   }
 
   pub(crate) fn write(&self, path: impl AsRef<Path>, bytes: impl AsRef<[u8]>) {
-    fs::write(self.env.resolve(path), bytes.as_ref()).unwrap();
+    fs::write(self.env.resolve(path).unwrap(), bytes.as_ref()).unwrap();
   }
 
   pub(crate) fn remove_file(&self, path: impl AsRef<Path>) {
-    fs::remove_file(self.env.resolve(path)).unwrap();
+    fs::remove_file(self.env.resolve(path).unwrap()).unwrap();
   }
 
   pub(crate) fn create_dir(&self, path: impl AsRef<Path>) {
-    fs::create_dir(self.env.resolve(path)).unwrap();
+    fs::create_dir(self.env.resolve(path).unwrap()).unwrap();
   }
 
   #[cfg(unix)]
   pub(crate) fn metadata(&self, path: impl AsRef<Path>) -> fs::Metadata {
-    fs::metadata(self.env.resolve(path)).unwrap()
+    fs::metadata(self.env.resolve(path).unwrap()).unwrap()
   }
 
   #[cfg(unix)]
   pub(crate) fn set_permissions(&self, path: impl AsRef<Path>, permissions: fs::Permissions) {
-    fs::set_permissions(self.env.resolve(path), permissions).unwrap();
+    fs::set_permissions(self.env.resolve(path).unwrap(), permissions).unwrap();
   }
 
   pub(crate) fn assert_ok(&mut self) {
@@ -90,7 +90,9 @@ impl TestEnv {
   }
 
   pub(crate) fn load_metainfo(&mut self, filename: impl AsRef<Path>) -> Metainfo {
-    let input = self.env.read(filename.as_ref().as_os_str().into()).unwrap();
+    let path = filename.as_ref();
+    let target = InputTarget::try_from(path.as_os_str()).unwrap();
+    let input = self.env.read(target).unwrap();
     Metainfo::from_input(&input).unwrap()
   }
 }

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -146,7 +146,7 @@ mod tests {
 
     let metainfo = env.load_metainfo("foo.torrent");
 
-    assert!(metainfo.verify(&env.resolve("foo"), None)?.good());
+    assert!(metainfo.verify(&env.resolve("foo")?, None)?.good());
 
     Ok(())
   }
@@ -177,7 +177,7 @@ mod tests {
 
     let metainfo = env.load_metainfo("foo.torrent");
 
-    let status = metainfo.verify(&env.resolve("foo"), None)?;
+    let status = metainfo.verify(&env.resolve("foo")?, None)?;
 
     assert_eq!(status.count_bad(), 0);
 


### PR DESCRIPTION
When an empty path is passed to `Env::resolve`, the result is the
current working directory. This is bad, so forbid the user to pass in
empty paths.