### PR TITLE
Use attractive paths in user-facing messages

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -18,11 +18,11 @@ pub(crate) enum Error {
   CommandInvoke { command: String, source: io::Error },
   #[snafu(display("Command `{}` returned bad exit status: {}", command, status))]
   CommandStatus { command: String, status: ExitStatus },
-  #[snafu(display("Filename was not valid unicode: {}", filename.display()))]
+  #[snafu(display("Filename was not valid unicode: `{}`", filename.display()))]
   FilenameDecode { filename: PathBuf },
-  #[snafu(display("Path had no file name: {}", path.display()))]
+  #[snafu(display("Path had no file name: `{}`", path.display()))]
   FilenameExtract { path: PathBuf },
-  #[snafu(display("Unknown file ordering: {}", text))]
+  #[snafu(display("Unknown file ordering: `{}`", text))]
   FileOrderUnknown { text: String },
   #[snafu(display("I/O error at `{}`: {}", path.display(), source))]
   Filesystem { source: io::Error, path: PathBuf },

--- a/src/input_target.rs
+++ b/src/input_target.rs
@@ -7,13 +7,6 @@ pub(crate) enum InputTarget {
 }
 
 impl InputTarget {
-  pub(crate) fn resolve(&self, env: &Env) -> Result<Self> {
-    match self {
-      Self::Path(path) => Ok(Self::Path(env.resolve(path)?)),
-      Self::Stdin => Ok(Self::Stdin),
-    }
-  }
-
   pub(crate) fn try_from_os_str(text: &OsStr) -> Result<Self, OsString> {
     text
       .try_into()

--- a/src/output_target.rs
+++ b/src/output_target.rs
@@ -1,6 +1,6 @@
 use crate::common::*;
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub(crate) enum OutputTarget {
   Path(PathBuf),
   Stdout,

--- a/src/subcommand/torrent/create/create_content.rs
+++ b/src/subcommand/torrent/create/create_content.rs
@@ -1,0 +1,153 @@
+use crate::common::*;
+
+use super::Create;
+
+pub(crate) struct CreateContent {
+  pub(crate) files: Option<Files>,
+  pub(crate) piece_length: Bytes,
+  pub(crate) progress_bar: ProgressBar,
+  pub(crate) name: String,
+  pub(crate) output: OutputTarget,
+}
+
+impl CreateContent {
+  pub(crate) fn from_create(create: &Create, env: &mut Env) -> Result<Self> {
+    match &create.input {
+      InputTarget::Path(path) => {
+        let spinner = if env.err().is_styled_term() {
+          let style = ProgressStyle::default_spinner()
+            .template("{spinner:.green} {msg:.bold}…")
+            .tick_chars(consts::TICK_CHARS);
+
+          Some(ProgressBar::new_spinner().with_style(style))
+        } else {
+          None
+        };
+
+        let files = Walker::new(&env.resolve(path)?)
+          .include_junk(create.include_junk)
+          .include_hidden(create.include_hidden)
+          .follow_symlinks(create.follow_symlinks)
+          .sort_by(create.sort_by.clone())
+          .globs(&create.globs)?
+          .spinner(spinner)
+          .files()?;
+
+        let piece_length = create
+          .piece_length
+          .unwrap_or_else(|| PieceLengthPicker::from_content_size(files.total_size()));
+
+        let style = ProgressStyle::default_bar()
+          .template(
+            "{spinner:.green} ⟪{elapsed_precise}⟫ ⟦{bar:40.cyan}⟧ \
+             {binary_bytes}/{binary_total_bytes} ⟨{binary_bytes_per_sec}, {eta}⟩",
+          )
+          .tick_chars(consts::TICK_CHARS)
+          .progress_chars(consts::PROGRESS_CHARS);
+
+        let progress_bar = ProgressBar::new(files.total_size().count()).with_style(style);
+
+        let resolved = env.resolve(path)?;
+
+        let filename = resolved
+          .file_name()
+          .ok_or_else(|| Error::FilenameExtract { path: path.clone() })?;
+
+        let name = match &create.name {
+          Some(name) => name.clone(),
+          None => filename
+            .to_str()
+            .ok_or_else(|| Error::FilenameDecode {
+              filename: PathBuf::from(filename),
+            })?
+            .to_owned(),
+        };
+
+        let output = create
+          .output
+          .clone()
+          .unwrap_or_else(|| OutputTarget::Path(Self::torrent_path(path, &name)));
+
+        Ok(Self {
+          files: Some(files),
+          piece_length,
+          progress_bar,
+          name,
+          output,
+        })
+      }
+
+      InputTarget::Stdin => {
+        let files = None;
+        let piece_length = create.piece_length.unwrap_or(Bytes::kib() * 256);
+
+        let style = ProgressStyle::default_bar()
+          .template("{spinner:.green} ⟪{elapsed_precise}⟫ {binary_bytes} ⟨{binary_bytes_per_sec}⟩")
+          .tick_chars(consts::TICK_CHARS);
+
+        let progress_bar = ProgressBar::new_spinner().with_style(style);
+
+        let name = create
+          .name
+          .clone()
+          .ok_or_else(|| Error::internal("Expected `--name` to be set when `--input -`."))?;
+
+        let output = create
+          .output
+          .clone()
+          .ok_or_else(|| Error::internal("Expected `--output` to be set when `--input -`."))?;
+
+        Ok(Self {
+          files,
+          piece_length,
+          progress_bar,
+          name,
+          output,
+        })
+      }
+    }
+  }
+
+  fn torrent_path(input: &Path, name: &str) -> PathBuf {
+    input.join("..").clean().join(format!("{}.torrent", name))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  use pretty_assertions::assert_eq;
+
+  #[test]
+  fn torrent_path() {
+    fn case(path: &str, name: &str, expected: impl AsRef<Path>) {
+      let expected = expected.as_ref();
+      assert_eq!(
+        CreateContent::torrent_path(Path::new(path), name),
+        expected,
+        "{} + {} != {}",
+        path,
+        name,
+        expected.display(),
+      );
+    }
+
+    use path::Component;
+
+    case("foo", "foo", "foo.torrent");
+    case("foo", "foo", "foo.torrent");
+    case("foo", "bar", "bar.torrent");
+    case("foo/bar", "foo", Path::new("foo").join("foo.torrent"));
+    case("foo/bar", "bar", Path::new("foo").join("bar.torrent"));
+    case(
+      "/foo/bar",
+      "bar",
+      Path::new(&Component::RootDir)
+        .join("foo")
+        .join("bar.torrent"),
+    );
+    case(".", "foo", Path::new("..").join("foo.torrent"));
+    case("..", "foo", Path::new("..").join("..").join("foo.torrent"));
+  }
+}

--- a/src/subcommand/torrent/create/create_step.rs
+++ b/src/subcommand/torrent/create/create_step.rs
@@ -1,16 +1,16 @@
 use crate::common::*;
 
 #[derive(Clone, Copy)]
-pub(crate) enum CreateStep<'output> {
-  Searching,
+pub(crate) enum CreateStep<'a> {
+  Searching { input: &'a InputTarget },
   Hashing,
-  Writing { output: &'output OutputTarget },
+  Writing { output: &'a OutputTarget },
 }
 
-impl<'output> Step for CreateStep<'output> {
+impl<'a> Step for CreateStep<'a> {
   fn n(&self) -> usize {
     match self {
-      Self::Searching => 1,
+      Self::Searching { .. } => 1,
       Self::Hashing => 2,
       Self::Writing { .. } => 3,
     }
@@ -18,7 +18,7 @@ impl<'output> Step for CreateStep<'output> {
 
   fn symbol(&self) -> &str {
     match self {
-      Self::Searching => "\u{1F9FF}",
+      Self::Searching { .. } => "\u{1F9FF}",
       Self::Hashing => "\u{1F9EE}",
       Self::Writing { .. } => "\u{1F4BE}",
     }
@@ -30,7 +30,11 @@ impl<'output> Step for CreateStep<'output> {
 
   fn write_message(&self, write: &mut dyn Write) -> io::Result<()> {
     match self {
-      Self::Searching => write!(write, "Searching for files…"),
+      Self::Searching { input } => match input {
+        InputTarget::Path(path) => write!(write, "Searching `{}` for files…", path.display()),
+        InputTarget::Stdin => write!(write, "Creating single-file torrent from standard input…"),
+      },
+
       Self::Hashing => write!(write, "Hashing pieces…"),
       Self::Writing { output } => write!(write, "Writing metainfo to {}…", output),
     }


### PR DESCRIPTION
If a user passes `--input foo`, print "Searching `foo` for files…",
instead of the resolved, absolute path to `foo`, since the former is
what the user typed in.

This was way harder, and had way more edge case, than I thought it would
be!

One takaway, lexical path cleaning is excellent.