### PR TITLE
Use `TestEnv::assert_ok` everywhere

### DIFF
--- a/src/subcommand/completions.rs
+++ b/src/subcommand/completions.rs
@@ -49,7 +49,7 @@ mod tests {
       tree: {},
     };
 
-    assert_matches!(env.run(), Ok(()));
+    env.assert_ok();
 
     assert!(env.out().starts_with("_imdl() {"));
   }

--- a/src/subcommand/torrent/create.rs
+++ b/src/subcommand/torrent/create.rs
@@ -467,7 +467,7 @@ mod tests {
       },
     };
 
-    assert_matches!(env.run(), Ok(()));
+    env.assert_ok();
   }
 
   #[test]
@@ -2231,7 +2231,7 @@ Content Size  9 bytes
       },
     };
 
-    assert_matches!(env.run(), Ok(()));
+    env.assert_ok();
   }
 
   #[test]
@@ -2248,7 +2248,7 @@ Content Size  9 bytes
       },
     };
 
-    assert_matches!(env.run(), Ok(()));
+    env.assert_ok();
     assert_eq!(env.out(), "");
   }
 
@@ -2267,7 +2267,7 @@ Content Size  9 bytes
       },
     };
 
-    assert_matches!(env.run(), Ok(()));
+    env.assert_ok();
     assert_eq!(
       env.out(),
       "magnet:?xt=urn:btih:516735f4b80f2b5487eed5f226075bdcde33a54e&dn=foo\n"
@@ -2291,7 +2291,7 @@ Content Size  9 bytes
       },
     };
 
-    assert_matches!(env.run(), Ok(()));
+    env.assert_ok();
     assert_eq!(
       env.out(),
       "magnet:\
@@ -2338,7 +2338,7 @@ Content Size  9 bytes
       },
     };
 
-    assert_matches!(env.run(), Ok(()));
+    env.assert_ok();
     assert_eq!(
       env.out(),
       "magnet:?xt=urn:btih:516735f4b80f2b5487eed5f226075bdcde33a54e&dn=foo&x.pe=foo:1337&x.pe=bar:\
@@ -2360,7 +2360,7 @@ Content Size  9 bytes
         foo: "",
       }
     };
-    assert_matches!(env.run(), Ok(()));
+    env.assert_ok();
     let torrent = env.resolve("foo.torrent")?;
     let err = fs::read(torrent).unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::NotFound);
@@ -2388,7 +2388,7 @@ Content Size  9 bytes
       }
     };
 
-    assert_matches!(env.run(), Ok(()));
+    env.assert_ok();
 
     let torrent = env.load_metainfo("foo.torrent");
     assert_eq!(torrent.file_paths(), &["a", "b", "c", "d/e"]);
@@ -2417,7 +2417,7 @@ Content Size  9 bytes
       }
     };
 
-    assert_matches!(env.run(), Ok(()));
+    env.assert_ok();
 
     let torrent = env.load_metainfo("foo.torrent");
     assert_eq!(torrent.file_paths(), &["a", "b", "c", "d/e"]);
@@ -2446,7 +2446,7 @@ Content Size  9 bytes
       }
     };
 
-    assert_matches!(env.run(), Ok(()));
+    env.assert_ok();
 
     let torrent = env.load_metainfo("foo.torrent");
     assert_eq!(torrent.file_paths(), &["d/a", "c", "b", "a"]);
@@ -2475,7 +2475,7 @@ Content Size  9 bytes
       }
     };
 
-    assert_matches!(env.run(), Ok(()));
+    env.assert_ok();
 
     let torrent = env.load_metainfo("foo.torrent");
     assert_eq!(torrent.file_paths(), &["b", "d/e", "a", "c"]);
@@ -2504,7 +2504,7 @@ Content Size  9 bytes
       }
     };
 
-    assert_matches!(env.run(), Ok(()));
+    env.assert_ok();
 
     let torrent = env.load_metainfo("foo.torrent");
     assert_eq!(torrent.file_paths(), &["c", "a", "b", "d/e"]);
@@ -2535,7 +2535,7 @@ Content Size  9 bytes
       }
     };
 
-    assert_matches!(env.run(), Ok(()));
+    env.assert_ok();
 
     let torrent = env.load_metainfo("foo.torrent");
     assert_eq!(torrent.file_paths(), &["d/e", "b", "a", "c"]);

--- a/src/subcommand/torrent/link.rs
+++ b/src/subcommand/torrent/link.rs
@@ -68,7 +68,6 @@ impl Link {
 mod tests {
   use super::*;
 
-  use claim::assert_ok;
   use pretty_assertions::assert_eq;
 
   #[test]
@@ -85,7 +84,7 @@ mod tests {
       }
     };
 
-    assert_ok!(env.run());
+    env.assert_ok();
 
     const INFO: &str = "d6:lengthi0e4:name3:foo12:piece lengthi1e6:pieces0:e";
 
@@ -114,7 +113,7 @@ mod tests {
       }
     };
 
-    assert_ok!(env.run());
+    env.assert_ok();
 
     const INFO: &str = "d6:lengthi0e4:name3:foo12:piece lengthi1e6:pieces0:e";
 
@@ -147,7 +146,7 @@ mod tests {
       }
     };
 
-    assert_ok!(env.run());
+    env.assert_ok();
 
     const INFO: &str = "d6:lengthi0e4:name3:foo12:piece lengthi1e6:pieces0:e";
 
@@ -180,7 +179,7 @@ mod tests {
       }
     };
 
-    assert_ok!(env.run());
+    env.assert_ok();
 
     const INFO: &str = "d6:lengthi0e4:name3:foo12:piece lengthi1e6:pieces0:e";
 
@@ -209,7 +208,7 @@ mod tests {
       }
     };
 
-    assert_ok!(env.run());
+    env.assert_ok();
 
     const INFO: &str = "d1:ai0e6:lengthi0e4:name3:foo12:piece lengthi1e6:pieces0:e";
 

--- a/src/subcommand/torrent/show.rs
+++ b/src/subcommand/torrent/show.rs
@@ -71,7 +71,7 @@ mod tests {
 
       metainfo.dump(path).unwrap();
 
-      env.run().unwrap();
+      env.assert_ok();
 
       let have = env.out();
       let want = "         Name  foo
@@ -108,7 +108,7 @@ Announce List  Tier 1: announce
 
       metainfo.dump(path).unwrap();
 
-      env.run().unwrap();
+      env.assert_ok();
 
       let have = env.out();
       let want = "\
@@ -173,7 +173,7 @@ files\tfoo
 
       metainfo.dump(path).unwrap();
 
-      env.run().unwrap();
+      env.assert_ok();
 
       let have = env.out();
       let want = "         Name  foo
@@ -210,7 +210,7 @@ Announce List  Tier 1: x
 
       metainfo.dump(path).unwrap();
 
-      env.run().unwrap();
+      env.assert_ok();
 
       let have = env.out();
       let want = "\
@@ -275,7 +275,7 @@ files\tfoo
 
       metainfo.dump(path).unwrap();
 
-      env.run().unwrap();
+      env.assert_ok();
 
       let have = env.out();
       let want = "         Name  foo
@@ -312,7 +312,7 @@ Announce List  Tier 1: b
 
       metainfo.dump(path).unwrap();
 
-      env.run().unwrap();
+      env.assert_ok();
 
       let have = env.out();
       let want = "\
@@ -377,7 +377,7 @@ files\tfoo
 
       metainfo.dump(path).unwrap();
 
-      env.run().unwrap();
+      env.assert_ok();
 
       let have = env.out();
       let want = "         Name  foo
@@ -410,7 +410,7 @@ Creation Date  1970-01-01 00:00:01 UTC
 
       metainfo.dump(path).unwrap();
 
-      env.run().unwrap();
+      env.assert_ok();
 
       let have = env.out();
       let want = "\

--- a/src/subcommand/torrent/verify.rs
+++ b/src/subcommand/torrent/verify.rs
@@ -119,7 +119,7 @@ mod tests {
       },
     };
 
-    create_env.run()?;
+    create_env.assert_ok();
 
     let torrent = create_env.resolve("foo.torrent")?;
 
@@ -133,7 +133,7 @@ mod tests {
       tree: {},
     };
 
-    assert_matches!(verify_env.run(), Ok(()));
+    verify_env.assert_ok();
 
     let want = format!(
       "[1/2] \u{1F4BE} Loading metainfo from `{}`…\n[2/2] \u{1F9EE} Verifying pieces from \
@@ -168,7 +168,7 @@ mod tests {
       },
     };
 
-    create_env.run()?;
+    create_env.assert_ok();
 
     create_env.write("foo/a", "xyz");
 
@@ -227,7 +227,7 @@ mod tests {
       },
     };
 
-    create_env.run()?;
+    create_env.assert_ok();
 
     let torrent = create_env.resolve("foo.torrent")?;
 
@@ -249,7 +249,7 @@ mod tests {
       tree: {},
     };
 
-    assert_matches!(verify_env.run(), Ok(()));
+    verify_env.assert_ok();
 
     let want = format!(
       "[1/2] \u{1F4BE} Loading metainfo from `{}`…\n[2/2] \u{1F9EE} Verifying pieces from \
@@ -284,7 +284,7 @@ mod tests {
       },
     };
 
-    create_env.run()?;
+    create_env.assert_ok();
 
     let torrent = create_env.resolve("foo.torrent")?;
     let content = create_env.resolve("foo")?;
@@ -302,7 +302,7 @@ mod tests {
       tree: {},
     };
 
-    assert_matches!(verify_env.run(), Ok(()));
+    verify_env.assert_ok();
 
     let want = format!(
       "[1/2] \u{1F4BE} Loading metainfo from standard input…\n[2/2] \u{1F9EE} Verifying pieces \
@@ -340,7 +340,7 @@ mod tests {
       },
     };
 
-    create_env.run()?;
+    create_env.assert_ok();
 
     let torrent = create_env.resolve("foo.torrent")?;
 
@@ -425,7 +425,7 @@ mod tests {
       },
     };
 
-    create_env.run()?;
+    create_env.assert_ok();
 
     let torrent = create_env.resolve("foo.torrent")?;
 
@@ -531,7 +531,7 @@ mod tests {
       },
     };
 
-    create_env.run()?;
+    create_env.assert_ok();
 
     let torrent = create_env.resolve("foo.torrent")?;
 
@@ -591,7 +591,7 @@ mod tests {
       },
     };
 
-    create_env.run()?;
+    create_env.assert_ok();
 
     let torrent = create_env.resolve("foo.torrent")?;
 
@@ -610,7 +610,7 @@ mod tests {
 
     fs::rename(create_env.resolve("foo")?, verify_env.resolve("foo")?).unwrap();
 
-    assert_matches!(verify_env.run(), Ok(()));
+    verify_env.assert_ok();
 
     let want = format!(
       "[1/2] \u{1F4BE} Loading metainfo from standard input…\n[2/2] \u{1F9EE} Verifying pieces \

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -142,7 +142,7 @@ mod tests {
       },
     };
 
-    env.run()?;
+    env.assert_ok();
 
     let metainfo = env.load_metainfo("foo.torrent");
 
@@ -171,7 +171,7 @@ mod tests {
       },
     };
 
-    env.run()?;
+    env.assert_ok();
 
     env.write("foo/a", "xyz");
 


### PR DESCRIPTION
`TestEnv::assert_ok` prints stderr and stdout, and so provides more
information in the event of an error.

Fixes:
- https://github.com/casey/intermodal/issues/330