### PR TITLE
Add more detail to installation instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 
 UNRELEASED - 2020-04-10
 -----------------------
-- :art: [`xxxxxxxxxxxx`](https://github.com/casey/intermodal/commits/master) Remove use of unreachable in favor of internal errors ([#351](https://github.com/casey/intermodal/pull/351)) - Fixes [#188](https://github.com/casey/intermodal/issues/188) - _Casey Rodarmor <casey@rodarmor.com>_
+- :package: [`xxxxxxxxxxxx`](https://github.com/casey/intermodal/commits/master) Improve install.sh and documentation ([#352](https://github.com/casey/intermodal/pull/352)) - _Casey Rodarmor <casey@rodarmor.com>_
+- :art: [`e54bdeb95d93`](https://github.com/casey/intermodal/commit/e54bdeb95d932bd5f81870f34999de37b615a69d) Remove use of unreachable in favor of internal errors ([#351](https://github.com/casey/intermodal/pull/351)) - Fixes [#188](https://github.com/casey/intermodal/issues/188) - _Casey Rodarmor <casey@rodarmor.com>_
 - :books: [`52b78b90f675`](https://github.com/casey/intermodal/commit/52b78b90f6751a72a64074619fbf19df2988ac14) Improve badges ([#350](https://github.com/casey/intermodal/pull/350)) - _Casey Rodarmor <casey@rodarmor.com>_
 
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,8 @@ For more about the project and its goals, check out [this post](https://rodarmor
 
 #### Supported Operating Systems
 
-`imdl` supports both unix and Windows. It is tested on Linux, MacOS, and
-Windows, but should work on other unix OSs. If it does not, please open an
-issue!
+`imdl` supports Linux, MacOS, and Windows, and should work on other unix OSes.
+If it does not, please open an issue!
 
 #### Pre-built binaries
 
@@ -42,11 +41,34 @@ Pre-built binaries for Linux, macOS, and Windows can be found on
 [the releases page](https://github.com/casey/intermodal/releases).
 
 You can use the following command to download the latest binary for Linux,
-MacOS or Windows, just replace `DEST` with the directory where you'd like to
+MacOS, or Windows, just replace `DEST` with the directory where you'd like to
 install the `imdl` binary:
 
 ```sh
 curl --proto '=https' --tlsv1.2 -sSf https://imdl.io/install.sh | bash -s -- --to DEST
+```
+
+A good place to install personal binaries is `~/bin`, which `install.sh` uses
+when `--to` is not supplied. To create the `~/bin` directory and install `imdl`
+there, do:
+
+```sh
+curl --proto '=https' --tlsv1.2 -sSf https://imdl.io/install.sh | bash
+```
+
+Additionally, you'll have to add `~/bin` to the `PATH` environment variable,
+which the system uses to find executables. How to do this depends on the shell.
+
+For `sh`, `bash`, and `zsh`, it should be done in `~/.profile`:
+
+```sh
+echo 'export PATH=$HOME/bin:$PATH' >> ~/.profile
+```
+
+For `fish`, it should be done in `~/.config/fish/config.fish`:
+
+```fish
+echo 'set -gx PATH ~/bin $PATH' >> ~/.config/fish/config.fish
 ```
 
 #### Cargo

--- a/www/install.sh
+++ b/www/install.sh
@@ -4,7 +4,7 @@ set -eu
 
 help() {
   cat <<'EOF'
-Install a binary release of a imdl hosted on GitHub
+Install a binary release of `imdl` hosted on GitHub
 
 Usage:
     install [options]
@@ -12,13 +12,14 @@ Usage:
 Options:
     -h, --help      Display this message
     -f, --force     Force overwriting an existing binary
-    --tag TAG       Tag (version) of the crate to install (default <latest release>)
-    --to LOCATION   Where to install the binary (default ~/.cargo/bin)
+    --tag TAG       Tag (version) to install (default <latest release>)
+    --to LOCATION   Where to install the binary (default ~/bin)
 EOF
 }
 
 git=casey/intermodal
 crate=imdl
+bin=imdl
 url=https://github.com/casey/intermodal
 releases=$url/releases
 
@@ -66,7 +67,7 @@ while test $# -gt 0; do
       shift
       ;;
     --to)
-      dest=$2
+      dst=$2
       shift
       ;;
     *)
@@ -89,8 +90,8 @@ if [ -z ${tag-} ]; then
   need rev
 fi
 
-if [ -z ${dest-} ]; then
-  dest="$HOME/.cargo/bin"
+if [ -z ${dst-} ]; then
+  dst="$HOME/bin"
 fi
 
 if [ -z ${tag-} ]; then
@@ -103,21 +104,17 @@ say_err "Repository:  $url"
 say_err "Crate:       $crate"
 say_err "Tag:         $tag"
 say_err "Target:      $target"
-say_err "Destination: $dest"
+say_err "Destination: $dst"
 say_err "Archive:     $archive"
 
 td=$(mktemp -d || mktemp -d -t tmp)
 curl -sL $archive | tar -C $td -xz
 
-for f in $(ls $td); do
-  test -x $td/$f || continue
-
-  if [ -e "$dest/$f" ] && [ $force = false ]; then
-    err "$f already exists in $dest"
-  else
-    mkdir -p $dest
-    install -m 755 $td/$f $dest
-  fi
-done
+if [ -e "$dst/$bin" ] && [ $force = false ]; then
+  err "$bin already exists in $dst"
+else
+  mkdir -p $dst
+  install -m 755 $td/$bin $dst
+fi
 
 rm -rf $td


### PR DESCRIPTION
- Change default install location to `~/bin`
- Suggestion installing in ~/bin
- Add instructions to create `~/bin`, install there, and add `~/bin` to
  the PATH variable.