### PR TITLE
Get current time early when creating torrents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 
 UNRELEASED - 2020-04-18
 -----------------------
-- :books: [`xxxxxxxxxxxx`](https://github.com/casey/intermodal/commits/master) Readme improvements - _Casey Rodarmor <casey@rodarmor.com>_
+- :art: [`xxxxxxxxxxxx`](https://github.com/casey/intermodal/commits/master) Get current time early when creating torrents - Fixes [#207](https://github.com/casey/intermodal/issues/207) - _Casey Rodarmor <casey@rodarmor.com>_
+- :books: [`9098d3684032`](https://github.com/casey/intermodal/commit/9098d368403232a07684cae8c0b9b1f1383dd2ce) Readme improvements - _Casey Rodarmor <casey@rodarmor.com>_
 - :art: [`04338e3501af`](https://github.com/casey/intermodal/commit/04338e3501afd155af47d0c4bda2c680d2a7a519) Merge documentation and changelog generation - _Casey Rodarmor <casey@rodarmor.com>_
 - :books: [`1f8023d13a39`](https://github.com/casey/intermodal/commit/1f8023d13a399e381176c20bbb6a71763b7c352a) Fix directory link in README - _Matt Boulanger <Celeo@users.noreply.github.com>_
 - :sparkles: [`cb8b5a691945`](https://github.com/casey/intermodal/commit/cb8b5a691945b8108676f95d2888774263be8cc8) Partially implement BEP 53 - Fixes [#245](https://github.com/casey/intermodal/issues/245) - _strickinato <aaronstrick@gmail.com>_

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,9 +412,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "725cf19794cf90aa94e65050cb4191ff5d8fa87a498383774c47b332e3af952e"
+checksum = "8a0d737e0f947a1864e93d33fdef4af8445a00d1ed8dc0c8ddb73139ea6abf15"
 dependencies = [
  "libc",
 ]
@@ -522,9 +522,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
+checksum = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
 
 [[package]]
 name = "libgit2-sys"
@@ -822,9 +822,9 @@ checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
 name = "regex"
-version = "1.3.6"
+version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6946991529684867e47d86474e3a6d0c0ab9b82d5821e314b1ede31fa3a4b3"
+checksum = "a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/src/subcommand/torrent/create.rs
+++ b/src/subcommand/torrent/create.rs
@@ -264,6 +264,16 @@ impl Create {
       return Err(Error::PrivateTrackerless);
     }
 
+    let creation_date = if self.no_creation_date {
+      None
+    } else {
+      Some(
+        SystemTime::now()
+          .duration_since(SystemTime::UNIX_EPOCH)?
+          .as_secs(),
+      )
+    };
+
     CreateStep::Searching { input: &self.input }.print(env)?;
 
     let content = CreateContent::from_create(&self, env)?;
@@ -294,16 +304,6 @@ impl Create {
     }
 
     let private = if self.private { Some(true) } else { None };
-
-    let creation_date = if self.no_creation_date {
-      None
-    } else {
-      Some(
-        SystemTime::now()
-          .duration_since(SystemTime::UNIX_EPOCH)?
-          .as_secs(),
-      )
-    };
 
     let created_by = if self.no_created_by {
       None


### PR DESCRIPTION
Since getting the system time is fallible, do it early when creating a
torrent, so as to avoid potentially wasting time searching and hashing.

type: reform
fixes:
- https://github.com/casey/intermodal/issues/207