### PR TITLE
Note install script only works on Linux and MacOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@ Changelog
 =========
 
 
-UNRELEASED - 2020-04-19
+UNRELEASED - 2020-04-20
 -----------------------
-- :books: [`xxxxxxxxxxxx`](https://github.com/casey/intermodal/commits/master) Fix 404.css link - _Casey Rodarmor <casey@rodarmor.com>_
+- :books: [`xxxxxxxxxxxx`](https://github.com/casey/intermodal/commits/master) Note install script only works on Linux and MacOS - Fixes [#371](https://github.com/casey/intermodal/issues/371) - _Casey Rodarmor <casey@rodarmor.com>_
+- :books: [`b67a2f1885c9`](https://github.com/casey/intermodal/commit/b67a2f1885c9445c08411457809f8893ebfa2045) Fix 404.css link - _Casey Rodarmor <casey@rodarmor.com>_
 - :books: [`87687f4decbb`](https://github.com/casey/intermodal/commit/87687f4decbbd216b32ea3c9001122c56d5a93fc) Add custom 404 page to site - _Casey Rodarmor <casey@rodarmor.com>_
 - :books: [`09b0ee316c03`](https://github.com/casey/intermodal/commit/09b0ee316c034848c3b50966e7b5e3ed720aef2b) Document piece length selection algorithm ([#392](https://github.com/casey/intermodal/pull/392)) - Fixes [#367](https://github.com/casey/intermodal/issues/367) - _Casey Rodarmor <casey@rodarmor.com>_
 - :books: [`3ed449ce9325`](https://github.com/casey/intermodal/commit/3ed449ce932509ac88bd4837d74c9cbbb0729da9) Generate reference sections with `bin/gen` - _Casey Rodarmor <casey@rodarmor.com>_

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ For more about the project and its goals, check out
   - [Supported Operating Systems](#supported-operating-systems)
   - [Packages](#packages)
   - [Pre-built binaries](#pre-built-binaries)
+  - [Linux and MacOS Install Script](#linux-and-macos-install-script)
   - [Cargo](#cargo)
 - [Shell Completion Scripts](#shell-completion-scripts)
 - [Chat](#chat)
@@ -53,9 +54,11 @@ If it does not, please open an issue!
 Pre-built binaries for Linux, macOS, and Windows can be found on
 [the releases page](https://github.com/casey/intermodal/releases).
 
-You can use the following command to download the latest binary for Linux,
-MacOS, or Windows, just replace `DEST` with the directory where you'd like to
-install the `imdl` binary:
+### Linux and MacOS Install Script
+
+You can use the following command on Linux and MacOS to download the latest
+binary, just replace `DEST` with the directory where you'd like to install the
+`imdl` binary:
 
 ```sh
 curl --proto '=https' --tlsv1.2 -sSf https://imdl.io/install.sh | bash -s -- --to DEST

--- a/bin/gen/templates/README.md
+++ b/bin/gen/templates/README.md
@@ -37,9 +37,11 @@ If it does not, please open an issue!
 Pre-built binaries for Linux, macOS, and Windows can be found on
 [the releases page](https://github.com/casey/intermodal/releases).
 
-You can use the following command to download the latest binary for Linux,
-MacOS, or Windows, just replace `DEST` with the directory where you'd like to
-install the `imdl` binary:
+### Linux and MacOS Install Script
+
+You can use the following command on Linux and MacOS to download the latest
+binary, just replace `DEST` with the directory where you'd like to install the
+`imdl` binary:
 
 ```sh
 curl --proto '=https' --tlsv1.2 -sSf https://imdl.io/install.sh | bash -s -- --to DEST


### PR DESCRIPTION
Unfortunately, the install script doesn't work on windows, due to:

- Powershell defining an alias that maps `curl` to `Invoke-WebRequest`,
  which is incompatible with `curl`.

- The absence of the `rev` command.

type: documentation
fixes:
- https://github.com/casey/intermodal/issues/371