### PR TITLE
Add `--terminal` override terminal autodetection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 
 UNRELEASED - 2020-04-20
 -----------------------
-- :books: [`xxxxxxxxxxxx`](https://github.com/casey/intermodal/commits/master) Note install script only works on Linux and MacOS - Fixes [#371](https://github.com/casey/intermodal/issues/371) - _Casey Rodarmor <casey@rodarmor.com>_
+- :sparkles: [`xxxxxxxxxxxx`](https://github.com/casey/intermodal/commits/master) Add `--terminal` override terminal autodetection - Fixes [#398](https://github.com/casey/intermodal/issues/398) - _Casey Rodarmor <casey@rodarmor.com>_
+- :books: [`70dbe93c6ab0`](https://github.com/casey/intermodal/commit/70dbe93c6ab01408dfc42e1b75664de13de16a51) Note install script only works on Linux and MacOS - Fixes [#371](https://github.com/casey/intermodal/issues/371) - _Casey Rodarmor <casey@rodarmor.com>_
 - :books: [`b67a2f1885c9`](https://github.com/casey/intermodal/commit/b67a2f1885c9445c08411457809f8893ebfa2045) Fix 404.css link - _Casey Rodarmor <casey@rodarmor.com>_
 - :books: [`87687f4decbb`](https://github.com/casey/intermodal/commit/87687f4decbbd216b32ea3c9001122c56d5a93fc) Add custom 404 page to site - _Casey Rodarmor <casey@rodarmor.com>_
 - :books: [`09b0ee316c03`](https://github.com/casey/intermodal/commit/09b0ee316c034848c3b50966e7b5e3ed720aef2b) Document piece length selection algorithm ([#392](https://github.com/casey/intermodal/pull/392)) - Fixes [#367](https://github.com/casey/intermodal/issues/367) - _Casey Rodarmor <casey@rodarmor.com>_

--- a/book/src/commands/imdl.md
+++ b/book/src/commands/imdl.md
@@ -10,6 +10,9 @@ USAGE:
 
 FLAGS:
     -h, --help        Print help message.
+    -t, --terminal    Disable automatic terminal detection and behave as if both
+                      standard output and standard error are connected to a
+                      terminal.
     -u, --unstable    Enable unstable features. To avoid premature stabilization
                       and excessive version churn, unstable features are
                       unavailable unless this flag is set. Unstable features are
@@ -18,7 +21,7 @@ FLAGS:
     -V, --version     Print version number.
 
 OPTIONS:
-        --color <WHEN>    Print colorful output according to `WHEN`. When
+    -c, --color <WHEN>    Print colorful output according to `WHEN`. When
                           `auto`, the default, colored output is only enabled if
                           imdl detects that it is connected to a terminal, the
                           `NO_COLOR` environment variable is not set, and the

--- a/completions/_imdl
+++ b/completions/_imdl
@@ -15,9 +15,12 @@ _imdl() {
 
     local context curcontext="$curcontext" state line
     _arguments "${_arguments_options[@]}" \
+'-c+[Print colorful output according to `WHEN`. When `auto`, the default, colored output is only enabled if imdl detects that it is connected to a terminal, the `NO_COLOR` environment variable is not set, and the `TERM` environment variable is not set to `dumb`.]: :(auto always never)' \
 '--color=[Print colorful output according to `WHEN`. When `auto`, the default, colored output is only enabled if imdl detects that it is connected to a terminal, the `NO_COLOR` environment variable is not set, and the `TERM` environment variable is not set to `dumb`.]: :(auto always never)' \
 '-u[Enable unstable features. To avoid premature stabilization and excessive version churn, unstable features are unavailable unless this flag is set. Unstable features are not bound by semantic versioning stability guarantees, and may be changed or removed at any time.]' \
 '--unstable[Enable unstable features. To avoid premature stabilization and excessive version churn, unstable features are unavailable unless this flag is set. Unstable features are not bound by semantic versioning stability guarantees, and may be changed or removed at any time.]' \
+'-t[Disable automatic terminal detection and behave as if both standard output and standard error are connected to a terminal.]' \
+'--terminal[Disable automatic terminal detection and behave as if both standard output and standard error are connected to a terminal.]' \
 '-h[Print help message.]' \
 '--help[Print help message.]' \
 '-V[Print version number.]' \

--- a/completions/_imdl.ps1
+++ b/completions/_imdl.ps1
@@ -19,9 +19,12 @@ Register-ArgumentCompleter -Native -CommandName 'imdl' -ScriptBlock {
 
     $completions = @(switch ($command) {
         'imdl' {
+            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'Print colorful output according to `WHEN`. When `auto`, the default, colored output is only enabled if imdl detects that it is connected to a terminal, the `NO_COLOR` environment variable is not set, and the `TERM` environment variable is not set to `dumb`.')
             [CompletionResult]::new('--color', 'color', [CompletionResultType]::ParameterName, 'Print colorful output according to `WHEN`. When `auto`, the default, colored output is only enabled if imdl detects that it is connected to a terminal, the `NO_COLOR` environment variable is not set, and the `TERM` environment variable is not set to `dumb`.')
             [CompletionResult]::new('-u', 'u', [CompletionResultType]::ParameterName, 'Enable unstable features. To avoid premature stabilization and excessive version churn, unstable features are unavailable unless this flag is set. Unstable features are not bound by semantic versioning stability guarantees, and may be changed or removed at any time.')
             [CompletionResult]::new('--unstable', 'unstable', [CompletionResultType]::ParameterName, 'Enable unstable features. To avoid premature stabilization and excessive version churn, unstable features are unavailable unless this flag is set. Unstable features are not bound by semantic versioning stability guarantees, and may be changed or removed at any time.')
+            [CompletionResult]::new('-t', 't', [CompletionResultType]::ParameterName, 'Disable automatic terminal detection and behave as if both standard output and standard error are connected to a terminal.')
+            [CompletionResult]::new('--terminal', 'terminal', [CompletionResultType]::ParameterName, 'Disable automatic terminal detection and behave as if both standard output and standard error are connected to a terminal.')
             [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help message.')
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help message.')
             [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version number.')

--- a/completions/imdl.bash
+++ b/completions/imdl.bash
@@ -50,7 +50,7 @@ _imdl() {
 
     case "${cmd}" in
         imdl)
-            opts=" -u -h -V  --unstable --help --version --color   torrent completions help"
+            opts=" -u -t -h -V -c  --unstable --terminal --help --version --color   torrent completions help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -58,6 +58,10 @@ _imdl() {
             case "${prev}" in
                 
                 --color)
+                    COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
+                    return 0
+                    ;;
+                    -c)
                     COMPREPLY=($(compgen -W "auto always never" -- "${cur}"))
                     return 0
                     ;;

--- a/completions/imdl.elvish
+++ b/completions/imdl.elvish
@@ -14,9 +14,12 @@ edit:completion:arg-completer[imdl] = [@words]{
     }
     completions = [
         &'imdl'= {
+            cand -c 'Print colorful output according to `WHEN`. When `auto`, the default, colored output is only enabled if imdl detects that it is connected to a terminal, the `NO_COLOR` environment variable is not set, and the `TERM` environment variable is not set to `dumb`.'
             cand --color 'Print colorful output according to `WHEN`. When `auto`, the default, colored output is only enabled if imdl detects that it is connected to a terminal, the `NO_COLOR` environment variable is not set, and the `TERM` environment variable is not set to `dumb`.'
             cand -u 'Enable unstable features. To avoid premature stabilization and excessive version churn, unstable features are unavailable unless this flag is set. Unstable features are not bound by semantic versioning stability guarantees, and may be changed or removed at any time.'
             cand --unstable 'Enable unstable features. To avoid premature stabilization and excessive version churn, unstable features are unavailable unless this flag is set. Unstable features are not bound by semantic versioning stability guarantees, and may be changed or removed at any time.'
+            cand -t 'Disable automatic terminal detection and behave as if both standard output and standard error are connected to a terminal.'
+            cand --terminal 'Disable automatic terminal detection and behave as if both standard output and standard error are connected to a terminal.'
             cand -h 'Print help message.'
             cand --help 'Print help message.'
             cand -V 'Print version number.'

--- a/completions/imdl.fish
+++ b/completions/imdl.fish
@@ -1,5 +1,6 @@
-complete -c imdl -n "__fish_use_subcommand" -l color -d 'Print colorful output according to `WHEN`. When `auto`, the default, colored output is only enabled if imdl detects that it is connected to a terminal, the `NO_COLOR` environment variable is not set, and the `TERM` environment variable is not set to `dumb`.' -r -f -a "auto always never"
+complete -c imdl -n "__fish_use_subcommand" -s c -l color -d 'Print colorful output according to `WHEN`. When `auto`, the default, colored output is only enabled if imdl detects that it is connected to a terminal, the `NO_COLOR` environment variable is not set, and the `TERM` environment variable is not set to `dumb`.' -r -f -a "auto always never"
 complete -c imdl -n "__fish_use_subcommand" -s u -l unstable -d 'Enable unstable features. To avoid premature stabilization and excessive version churn, unstable features are unavailable unless this flag is set. Unstable features are not bound by semantic versioning stability guarantees, and may be changed or removed at any time.'
+complete -c imdl -n "__fish_use_subcommand" -s t -l terminal -d 'Disable automatic terminal detection and behave as if both standard output and standard error are connected to a terminal.'
 complete -c imdl -n "__fish_use_subcommand" -s h -l help -d 'Print help message.'
 complete -c imdl -n "__fish_use_subcommand" -s V -l version -d 'Print version number.'
 complete -c imdl -n "__fish_use_subcommand" -f -a "torrent" -d 'Subcommands related to the BitTorrent protocol.'

--- a/man/imdl.1
+++ b/man/imdl.1
@@ -11,6 +11,10 @@ imdl [FLAGS] [OPTIONS] <SUBCOMMAND>
 \fB\-h\fR, \fB\-\-help\fR
 Print help message.
 .TP
+\fB\-t\fR, \fB\-\-terminal\fR
+Disable automatic terminal detection and behave as if both standard output and standard error are
+connected to a terminal.
+.TP
 \fB\-u\fR, \fB\-\-unstable\fR
 Enable unstable features. To avoid premature stabilization and excessive version churn, unstable
 features are unavailable unless this flag is set. Unstable features are not bound by semantic
@@ -20,7 +24,7 @@ versioning stability guarantees, and may be changed or removed at any time.
 Print version number.
 .SH "OPTIONS:"
 .TP
-\fB\-\-color\fR <WHEN>
+\fB\-c\fR, \fB\-\-color\fR <WHEN>
 Print colorful output according to `WHEN`. When `auto`, the default, colored output is only
 enabled if imdl detects that it is connected to a terminal, the `NO_COLOR` environment
 variable is not set, and the `TERM` environment variable is not set to `dumb`. [default: auto]

--- a/src/env.rs
+++ b/src/env.rs
@@ -56,6 +56,11 @@ impl Env {
     self.err.set_use_color(use_color);
     self.out.set_use_color(use_color);
 
+    if args.options().terminal {
+      self.err.set_is_term(true);
+      self.out.set_is_term(true);
+    }
+
     args.run(self)
   }
 
@@ -241,5 +246,43 @@ mod tests {
     }
 
     assert_eq!(env.out(), "");
+  }
+
+  #[test]
+  fn terminal() -> Result<()> {
+    let mut create_env = test_env! {
+      args: [
+        "torrent",
+        "create",
+        "--input",
+        "foo",
+        "--announce",
+        "udp:bar.com",
+      ],
+      tree: {
+        foo: "",
+      }
+    };
+
+    create_env.assert_ok();
+
+    let mut env = test_env! {
+      args: [
+        "--terminal",
+        "torrent",
+        "show",
+        "--input",
+        create_env.resolve("foo.torrent")?,
+      ],
+      tree: {
+      }
+    };
+
+    env.assert_ok();
+
+    assert_eq!(env.err(), "");
+    assert!(env.out().starts_with("         Name"));
+
+    Ok(())
   }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -13,6 +13,7 @@ pub(crate) struct Options {
   unstable: bool,
   #[structopt(
     long = "color",
+    short = "c",
     value_name = "WHEN",
     default_value = UseColor::Auto.into(),
     possible_values = UseColor::VARIANTS,
@@ -22,6 +23,13 @@ pub(crate) struct Options {
             `dumb`.",
   )]
   pub(crate) use_color: UseColor,
+  #[structopt(
+    long = "terminal",
+    short = "t",
+    help = "Disable automatic terminal detection and behave as if both standard output and \
+            standard error are connected to a terminal."
+  )]
+  pub(crate) terminal: bool,
 }
 
 impl Options {

--- a/src/output_stream.rs
+++ b/src/output_stream.rs
@@ -41,6 +41,10 @@ impl OutputStream {
     }
   }
 
+  pub(crate) fn set_is_term(&mut self, term: bool) {
+    self.term = term;
+  }
+
   pub(crate) fn is_term(&self) -> bool {
     self.term
   }


### PR DESCRIPTION
The `--terminal` flag can be used to override terminal autodetection and
force `imdl` to behave as if standard error and standard output are
connected to a terminal.

type: added
fixes:
- https://github.com/casey/intermodal/issues/398