### PR TITLE
Get `st_flags` from `MetadataExt` on MacOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 
 UNRELEASED - 2020-04-21
 -----------------------
-- :sparkles: [`xxxxxxxxxxxx`](https://github.com/casey/intermodal/commits/master) Allow suppressing output with `--quiet` - Fixes [#174](https://github.com/casey/intermodal/issues/174) - _Celeo <celeodor@gmail.com>_
+- :art: [`xxxxxxxxxxxx`](https://github.com/casey/intermodal/commits/master) Get `st_flags` from `MetadataExt` on MacOS - _Casey Rodarmor <casey@rodarmor.com>_
+- :sparkles: [`deca555ac3b3`](https://github.com/casey/intermodal/commit/deca555ac3b3b8f665ee6415f80e05b2bb5e4af7) Allow suppressing output with `--quiet` - Fixes [#174](https://github.com/casey/intermodal/issues/174) - _Celeo <celeodor@gmail.com>_
 - :books: [`838167c4d3bc`](https://github.com/casey/intermodal/commit/838167c4d3bcbe2fa28f27a00bd94b959ad31e15) Describe in FAQ creating torrent from git repo - _Casey Rodarmor <casey@rodarmor.com>_
 - :sparkles: [`9b72873ed13e`](https://github.com/casey/intermodal/commit/9b72873ed13e8f0ae747714545c48c6e37c67dd0) Optionally respect `.gitignore` in `imdl torrent create` - Fixes [#378](https://github.com/casey/intermodal/issues/378) - _Celeo <celeodor@gmail.com>_
 - :books: [`9f480624616b`](https://github.com/casey/intermodal/commit/9f480624616b77995befec722effda22cc2d06ad) Improve FAQ template - _Casey Rodarmor <casey@rodarmor.com>_


### PR DESCRIPTION
I missed that `st_flags` is available on `MetadataExt` on MacOS, so get
them from there, instead of calling `libc::stat`.

type: reform