### PR TITLE
Allow positional shell to `imdl completions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 
 UNRELEASED - 2020-04-22
 -----------------------
-- :art: [`xxxxxxxxxxxx`](https://github.com/casey/intermodal/commits/master) Use `lexiclean` crate for lexical path cleaning - _Casey Rodarmor <casey@rodarmor.com>_
+- :zap: [`xxxxxxxxxxxx`](https://github.com/casey/intermodal/commits/master) Allow positional shell to `imdl completions` - Fixes [#375](https://github.com/casey/intermodal/issues/375) - _Casey Rodarmor <casey@rodarmor.com>_
+- :art: [`134c241ae7f8`](https://github.com/casey/intermodal/commit/134c241ae7f8e374d8a9266e7eb0c4a9c3844c30) Use `lexiclean` crate for lexical path cleaning - _Casey Rodarmor <casey@rodarmor.com>_
 - :zap: [`323434d0aa21`](https://github.com/casey/intermodal/commit/323434d0aa21ebfda5be85ecd4a38a55ed3fec0a) Allow positional input to `imdl torrent verify` - Fixes [#375](https://github.com/casey/intermodal/issues/375) - _Casey Rodarmor <casey@rodarmor.com>_
 - :zap: [`5ba885dbc4f2`](https://github.com/casey/intermodal/commit/5ba885dbc4f24781d6a3240ddfc0c03177b12f1e) Take input to `imdl torrent create` as positional - Fixes [#375](https://github.com/casey/intermodal/issues/375) - _Casey Rodarmor <casey@rodarmor.com>_
 - :wrench: [`c22df5a08326`](https://github.com/casey/intermodal/commit/c22df5a083265b03abd5531b1f5b2aad60aa68cd) Don't commit man pages - _Casey Rodarmor <casey@rodarmor.com>_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 
 UNRELEASED - 2020-04-22
 -----------------------
-- :bug: [`xxxxxxxxxxxx`](https://github.com/casey/intermodal/commits/master) Fix help strings - _Casey Rodarmor <casey@rodarmor.com>_
+- :zap: [`xxxxxxxxxxxx`](https://github.com/casey/intermodal/commits/master) Allow positional input to `imdl torrent show` - Fixes [#375](https://github.com/casey/intermodal/issues/375) - _Casey Rodarmor <casey@rodarmor.com>_
+- :bug: [`cecd2f66a5d6`](https://github.com/casey/intermodal/commit/cecd2f66a5d6a6b44f27f8ca499e359d82d29ab7) Fix help strings - _Casey Rodarmor <casey@rodarmor.com>_
 - :zap: [`ebec2d591a7a`](https://github.com/casey/intermodal/commit/ebec2d591a7a0e2a2c4cd55217db4ba46b5dd9ed) Allow positional shell to `imdl completions` - Fixes [#375](https://github.com/casey/intermodal/issues/375) - _Casey Rodarmor <casey@rodarmor.com>_
 - :art: [`134c241ae7f8`](https://github.com/casey/intermodal/commit/134c241ae7f8e374d8a9266e7eb0c4a9c3844c30) Use `lexiclean` crate for lexical path cleaning - _Casey Rodarmor <casey@rodarmor.com>_
 - :zap: [`323434d0aa21`](https://github.com/casey/intermodal/commit/323434d0aa21ebfda5be85ecd4a38a55ed3fec0a) Allow positional input to `imdl torrent verify` - Fixes [#375](https://github.com/casey/intermodal/issues/375) - _Casey Rodarmor <casey@rodarmor.com>_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 
 UNRELEASED - 2020-04-22
 -----------------------
-- :zap: [`xxxxxxxxxxxx`](https://github.com/casey/intermodal/commits/master) Allow positional shell to `imdl completions` - Fixes [#375](https://github.com/casey/intermodal/issues/375) - _Casey Rodarmor <casey@rodarmor.com>_
+- :bug: [`xxxxxxxxxxxx`](https://github.com/casey/intermodal/commits/master) Fix help strings - _Casey Rodarmor <casey@rodarmor.com>_
+- :zap: [`ebec2d591a7a`](https://github.com/casey/intermodal/commit/ebec2d591a7a0e2a2c4cd55217db4ba46b5dd9ed) Allow positional shell to `imdl completions` - Fixes [#375](https://github.com/casey/intermodal/issues/375) - _Casey Rodarmor <casey@rodarmor.com>_
 - :art: [`134c241ae7f8`](https://github.com/casey/intermodal/commit/134c241ae7f8e374d8a9266e7eb0c4a9c3844c30) Use `lexiclean` crate for lexical path cleaning - _Casey Rodarmor <casey@rodarmor.com>_
 - :zap: [`323434d0aa21`](https://github.com/casey/intermodal/commit/323434d0aa21ebfda5be85ecd4a38a55ed3fec0a) Allow positional input to `imdl torrent verify` - Fixes [#375](https://github.com/casey/intermodal/issues/375) - _Casey Rodarmor <casey@rodarmor.com>_
 - :zap: [`5ba885dbc4f2`](https://github.com/casey/intermodal/commit/5ba885dbc4f24781d6a3240ddfc0c03177b12f1e) Take input to `imdl torrent create` as positional - Fixes [#375](https://github.com/casey/intermodal/issues/375) - _Casey Rodarmor <casey@rodarmor.com>_

--- a/src/subcommand/torrent/create.rs
+++ b/src/subcommand/torrent/create.rs
@@ -5,9 +5,9 @@ use create_step::CreateStep;
 mod create_content;
 mod create_step;
 
-const INPUT_HELP: &str = "Read torrent contents from `PATH`. If `PATH` is a file, torrent will be \
-                          a single-file torrent.  If `PATH` is a directory, torrent will be a \
-                          multi-file torrent.  If `PATH` is `-`, read from standard input. Piece \
+const INPUT_HELP: &str = "Read torrent contents from `INPUT`. If `INPUT` is a file, torrent will \
+                          be a single-file torrent.  If `INPUT` is a directory, torrent will be a \
+                          multi-file torrent.  If `INPUT` is `-`, read from standard input. Piece \
                           length defaults to 256KiB when reading from standard input if \
                           `--piece-length` is not given.";
 
@@ -138,7 +138,7 @@ Examples:
     name = INPUT_FLAG,
     long = "input",
     short = "i",
-    value_name = "PATH",
+    value_name = "INPUT",
     empty_values = false,
     parse(try_from_os_str = InputTarget::try_from_os_str),
     help = INPUT_HELP,

--- a/src/subcommand/torrent/link.rs
+++ b/src/subcommand/torrent/link.rs
@@ -68,7 +68,7 @@ impl Link {
       &self.input_positional,
     )?;
 
-    let input = env.read(input.clone())?;
+    let input = env.read(input)?;
 
     let infohash = Infohash::from_input(&input)?;
     let metainfo = Metainfo::from_input(&input)?;

--- a/src/subcommand/torrent/verify.rs
+++ b/src/subcommand/torrent/verify.rs
@@ -3,8 +3,8 @@ use verify_step::VerifyStep;
 
 mod verify_step;
 
-const METAINFO_HELP: &str = "Verify torrent contents against torrent metainfo in `METAINFO`. If \
-                             `METAINFO` is `-`, read metainfo from standard input.";
+const METAINFO_HELP: &str = "Verify torrent contents against torrent metainfo in `INPUT`. If \
+                             `INPUT` is `-`, read metainfo from standard input.";
 
 const INPUT_POSITIONAL: &str = "<INPUT>";
 
@@ -41,7 +41,7 @@ pub(crate) struct Verify {
     name = INPUT_FLAG,
     long = "input",
     short = "i",
-    value_name = "METAINFO",
+    value_name = "INPUT",
     empty_values = false,
     parse(try_from_os_str = InputTarget::try_from_os_str),
     help = METAINFO_HELP,

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -8,19 +8,29 @@ macro_rules! test_env {
     $(err_style: $err_style:expr,)?
     tree: {
       $($tree:tt)*
-    } $(,)?
+    }
+    $(, matches: $result:pat)?
+
+    $(,)?
   } => {
     {
       let tempdir = temptree! { $($tree)* };
 
-      TestEnvBuilder::new()
+      let env = TestEnvBuilder::new()
         $(.current_dir(tempdir.path().join($cwd)))?
         $(.err_style($err_style))?
         $(.input($input))?
         .tempdir(tempdir)
         .arg("imdl")
         $(.arg($arg))*
-        .build()
+        .build();
+
+      $(
+        let mut env = env;
+        assert_matches!(env.run(), $result);
+      )?
+
+      env
     }
   }
 }


### PR DESCRIPTION
The shell can now be passed to `imdl completions` without a flag:

  imdl completions bash

Passing the shell by flag continues to work.

type: changed
fixes:
- https://github.com/casey/intermodal/issues/375