### PR TITLE
Don't invalid build cache when `Cargo.lock` changes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,19 +49,19 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-registry
 
     - name: Cache cargo index
       uses: actions/cache@v1
       with:
         path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-index
 
     - name: Cache cargo build
       uses: actions/cache@v1
       with:
         path: target
-        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-build-target
 
     - name: Install Stable
       uses: actions-rs/toolchain@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 
 UNRELEASED - 2020-04-23
 -----------------------
-- :books: [`xxxxxxxxxxxx`](https://github.com/casey/intermodal/commits/master) Remove watch dropdown image from readme - _Casey Rodarmor <casey@rodarmor.com>_
+- :wrench: [`xxxxxxxxxxxx`](https://github.com/casey/intermodal/commits/master) Don't invalid build cache when `Cargo.lock` changes - _Casey Rodarmor <casey@rodarmor.com>_
+- :books: [`c75ec39b14bb`](https://github.com/casey/intermodal/commit/c75ec39b14bb4375a875d2d2c73718b44eb54e12) Remove watch dropdown image from readme - _Casey Rodarmor <casey@rodarmor.com>_
 - :books: [`8fbe39726fe6`](https://github.com/casey/intermodal/commit/8fbe39726fe6c5bdc342dbd0764f8052ddd03597) Add notes for packagers to readme - _Casey Rodarmor <casey@rodarmor.com>_
 - :bug: [`43788cac9a0c`](https://github.com/casey/intermodal/commit/43788cac9a0cb957605fbd16299d04d36a7e0411) Fix `bin/package` - _Casey Rodarmor <casey@rodarmor.com>_
 


### PR DESCRIPTION
I copied the gihub actions caching configuration from examples, and I'm
not sure it's optimal. In particular, it causes a cache miss whenever
any `Cargo.lock` changes. I suspect that it would be better to always
hit the cache, and let cargo figure out what it needs to rebuild.

type: development