### PR TITLE
Adds support for BEP 39.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@ Changelog
 =========
 
 
-UNRELEASED - 2020-04-25
+UNRELEASED - 2020-04-28
 -----------------------
-- :books: [`xxxxxxxxxxxx`](https://github.com/casey/intermodal/commits/master) Improve documentation - _Casey Rodarmor <casey@rodarmor.com>_
+- :sparkles: [`xxxxxxxxxxxx`](https://github.com/casey/intermodal/commits/master) Add support for BEP 39. - Fixes [#98](https://github.com/casey/intermodal/issues/98) - _Annie Cherkaev <annie.cherk@gmail.com>_
+- :books: [`d077da405e1f`](https://github.com/casey/intermodal/commit/d077da405e1f50e4b1f2dc78cf821105640c9110) Improve documentation - _Casey Rodarmor <casey@rodarmor.com>_
 - :wrench: [`f8711a79a3d9`](https://github.com/casey/intermodal/commit/f8711a79a3d92da5b30fd3e8b7bba7a5e2d73766) Improve the done and merge recipes - _Casey Rodarmor <casey@rodarmor.com>_
 - :wrench: [`97ee5684f8e0`](https://github.com/casey/intermodal/commit/97ee5684f8e0f8de7dbdb4f930018c8df0f012b1) Don't invalid build cache when `Cargo.lock` changes - _Casey Rodarmor <casey@rodarmor.com>_
 - :books: [`c75ec39b14bb`](https://github.com/casey/intermodal/commit/c75ec39b14bb4375a875d2d2c73718b44eb54e12) Remove watch dropdown image from readme - _Casey Rodarmor <casey@rodarmor.com>_

--- a/src/info.rs
+++ b/src/info.rs
@@ -20,6 +20,13 @@ pub(crate) struct Info {
   pub(crate) pieces: PieceList,
   #[serde(flatten)]
   pub(crate) mode: Mode,
+  #[serde(
+    skip_serializing_if = "Option::is_none",
+    default,
+    with = "unwrap_or_skip",
+    rename = "update-url"
+  )]
+  pub(crate) update_url: Option<String>,
 }
 
 impl Info {

--- a/src/into_u64.rs
+++ b/src/into_u64.rs
@@ -1,7 +1,7 @@
 use crate::common::*;
 
 // Systems with pointers larger than 64 bits may eventually exist, but
-// for now let's assume that usize is at most 32 bits, and document that
+// for now let's assume that usize is at most 64 bits, and document that
 // assumption with this assert.
 const_assert!(std::mem::size_of::<usize>() <= std::mem::size_of::<u64>());
 

--- a/src/metainfo.rs
+++ b/src/metainfo.rs
@@ -143,6 +143,7 @@ mod tests {
           length: Bytes(20),
           md5sum: None,
         },
+        update_url: None,
       },
     };
 
@@ -176,6 +177,7 @@ mod tests {
             md5sum: Some(Md5Digest::from_hex("000102030405060708090a0b0c0d0e0f")),
           }],
         },
+        update_url: None,
       },
     };
 
@@ -224,6 +226,7 @@ mod tests {
           length: Bytes(5),
           md5sum: Some(Md5Digest::from_hex("000102030405060708090a0b0c0d0e0f")),
         },
+        update_url: None,
       },
     };
 
@@ -279,6 +282,7 @@ mod tests {
           length: Bytes(5),
           md5sum: None,
         },
+        update_url: None,
       },
     };
 
@@ -321,6 +325,7 @@ mod tests {
             path: FilePath::from_components(&["a", "b"]),
           }],
         },
+        update_url: None,
       },
     };
 
@@ -369,6 +374,7 @@ mod tests {
             path: FilePath::from_components(&["a", "b"]),
           }],
         },
+        update_url: None,
       },
     };
 
@@ -413,6 +419,7 @@ mod tests {
           length: Bytes(5),
           md5sum: None,
         },
+        update_url: None,
       },
     };
 
@@ -453,6 +460,7 @@ mod tests {
           length: Bytes(5),
           md5sum: None,
         },
+        update_url: None,
       },
     };
 

--- a/src/subcommand/torrent/show.rs
+++ b/src/subcommand/torrent/show.rs
@@ -133,6 +133,7 @@ mod tests {
           length: Bytes(20),
           md5sum: None,
         },
+        update_url: None,
       },
     };
 
@@ -273,6 +274,7 @@ files\tfoo
           length: Bytes(20),
           md5sum: None,
         },
+        update_url: None,
       },
     };
 
@@ -375,6 +377,7 @@ files\tfoo
           length: Bytes(20),
           md5sum: None,
         },
+        update_url: None,
       },
     };
 
@@ -477,6 +480,7 @@ files\tfoo
           length: Bytes(20),
           md5sum: None,
         },
+        update_url: None,
       },
     };
 


### PR DESCRIPTION
Adds update-url field to info struct.
See BEP 39 for more details: http://bittorrent.org/beps/bep_0039.html

type: added
fixes:
- https://github.com/casey/intermodal/issues/98