### PR TITLE
Metainfo refactoring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ strum_macros      = "0.18.0"
 syn               = "1.0.14"
 tempfile          = "3.0.0"
 unicode-width     = "0.1.0"
-url               = "2.1.1"
 
 [dependencies.bendy]
 version  = "0.3.0"
@@ -56,6 +55,10 @@ features = ["derive"]
 [dependencies.structopt]
 version  = "0.3.0"
 features = ["default", "wrap_help"]
+
+[dependencies.url]
+version = "2.1.1"
+features = ["serde"]
 
 [dev-dependencies]
 claim    = "0.3.1"

--- a/src/info.rs
+++ b/src/info.rs
@@ -26,7 +26,7 @@ pub(crate) struct Info {
     with = "unwrap_or_skip",
     rename = "update-url"
   )]
-  pub(crate) update_url: Option<String>,
+  pub(crate) update_url: Option<Url>,
 }
 
 impl Info {

--- a/src/subcommand/torrent/create.rs
+++ b/src/subcommand/torrent/create.rs
@@ -382,13 +382,13 @@ impl Create {
     }
 
     let info = Info {
-      source: self.source,
-      piece_length: content.piece_length,
       name: content.name,
+      piece_length: content.piece_length,
+      source: self.source,
+      update_url: self.update_url,
       mode,
       pieces,
       private,
-      update_url: self.update_url.map(|url| url.to_string()),
     };
 
     let metainfo = Metainfo {
@@ -3187,8 +3187,8 @@ Content Size  9 bytes
     env.assert_ok();
     let metainfo = env.load_metainfo("foo.torrent");
     assert_eq!(
-      metainfo.info.update_url.as_deref(),
-      Some("https://www.a_real_url.com/")
+      metainfo.info.update_url,
+      Some("https://www.a_real_url.com/".parse().unwrap())
     );
   }
 }

--- a/src/torrent_summary.rs
+++ b/src/torrent_summary.rs
@@ -105,6 +105,10 @@ impl TorrentSummary {
       table.tiers("Announce List", value);
     }
 
+    if let Some(update_url) = &self.metainfo.info.update_url {
+      table.row("Update URL", update_url);
+    }
+
     if let Some(nodes) = &self.metainfo.nodes {
       table.list(
         "DHT Nodes",


### PR DESCRIPTION
- Combine test Metainfo values into a small number of globally available
  values.
- Serialize update URLs as `URL` insted of `String`.
- Add additional `show` tests

type: reform