### PR TITLE
Add `--no-git` flag to `gen book`

### DIFF
--- a/bin/gen/src/summary.rs
+++ b/bin/gen/src/summary.rs
@@ -5,10 +5,11 @@ use crate::common::*;
 pub(crate) struct Summary {
   pub(crate) commands: String,
   pub(crate) references: String,
+  pub(crate) include_changelog: bool,
 }
 
 impl Summary {
-  pub(crate) fn new(project: &Project) -> Summary {
+  pub(crate) fn new(project: &Project, include_changelog: bool) -> Summary {
     let mut commands = Index::new("Commands", "./commands.md");
 
     for subcommand in &project.bin.subcommands {
@@ -27,6 +28,7 @@ impl Summary {
     Summary {
       commands: commands.text(),
       references: references.text(),
+      include_changelog,
     }
   }
 }

--- a/bin/gen/templates/SUMMARY.md
+++ b/bin/gen/templates/SUMMARY.md
@@ -5,7 +5,9 @@ Summary
 
 - [FAQ](./faq.md)
 
+{% if include_changelog %}
 - [Changelog](./changelog.md)
+{% endif %}
 
 {{commands}}
 


### PR DESCRIPTION
Skip generating the changelog for the book when `--no-git` is passed to
`gen book` or `gen all`.

type: added