### PR TITLE
Remove Keybase and IRC links from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,9 +219,7 @@ watch the intermodal repository in "Releases only" mode.
 
 ## Chat
 
-The primary chat is on [Discord](https://discord.gg/HaaT5Qz), but I try to also
-check [Keybase](https://keybase.io/team/intermodal) and
-[IRC](ircs://chat.freenode.net:6697/#intermodal) as time permits.
+The primary chat is on [Discord](https://discord.gg/HaaT5Qz).
 
 ## Contributing
 

--- a/bin/gen/templates/README.md
+++ b/bin/gen/templates/README.md
@@ -194,9 +194,7 @@ watch the intermodal repository in "Releases only" mode.
 
 ## Chat
 
-The primary chat is on [Discord](https://discord.gg/HaaT5Qz), but I try to also
-check [Keybase](https://keybase.io/team/intermodal) and
-[IRC](ircs://chat.freenode.net:6697/#intermodal) as time permits.
+The primary chat is on [Discord](https://discord.gg/HaaT5Qz).
 
 ## Contributing
 


### PR DESCRIPTION
Keybase and IRC chat never got any users, and since I never check them
and they get no traffic, it's probably best to remove them from the
readme.

type: documentation