### PR TITLE
Add Scoop package to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ If it does not, please open an issue!
 | [Arch Linux](https://www.archlinux.org)                              | [Yay](https://github.com/Jguer/yay)                | [intermodal](https://aur.archlinux.org/packages/intermodal)<sup>AUR</sup>                         | `yay -S intermodal`                                                                   |
 | [Arch Linux](https://www.archlinux.org)                              | Manual Installation                                | [intermodal](https://aur.archlinux.org/packages/intermodal)<sup>AUR</sup>                         | [wiki](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages) |
 | [Void Linux](https://voidlinux.org)                                  | [XBPS](https://docs.voidlinux.org/xbps/index.html) | [intermodal](https://github.com/void-linux/void-packages/blob/master/srcpkgs/intermodal/template) | `xbps-install -S intermodal`                                                          |
+| [Windows](https://www.microsoft.com/en-us/windows)                   | [Scoop](https://scoop.sh)                          | [intermodal](https://github.com/ScoopInstaller/Main/blob/master/bucket/intermodal.json)           | `scoop install intermodal`                                                            |
 
 ### Pre-built binaries
 

--- a/bin/gen/config.yaml
+++ b/bin/gen/config.yaml
@@ -66,6 +66,11 @@ packages:
   package:          '[intermodal](https://github.com/void-linux/void-packages/blob/master/srcpkgs/intermodal/template)'
   command:          '`xbps-install -S intermodal`'
 
+- operating-system: '[Windows](https://www.microsoft.com/en-us/windows)'
+  package-manager:  '[Scoop](https://scoop.sh)'
+  package:          '[intermodal](https://github.com/ScoopInstaller/Main/blob/master/bucket/intermodal.json)'
+  command:          '`scoop install intermodal`'
+
 references:
   - title: BitTorrent
     entries:


### PR DESCRIPTION
Will undraft when https://github.com/ScoopInstaller/Main/pull/1369 is merged.

(PS: For the next release, please consider adding x86 Windows builds, if possible. If you do add that to a future release, I can add it to the Scoop manifest as well.)