### PR TITLE
Make changelog author more concise

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,19 +49,19 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.cargo/registry
-        key: v0-${{ runner.os }}-cargo-registry
+        key: v1-${{ runner.os }}-cargo-registry
 
     - name: Cache cargo index
       uses: actions/cache@v1
       with:
         path: ~/.cargo/git
-        key: v0-${{ runner.os }}-cargo-index
+        key: v1-${{ runner.os }}-cargo-index
 
     - name: Cache cargo build
       uses: actions/cache@v1
       with:
         path: target
-        key: v0-${{ runner.os }}-cargo-build-target
+        key: v1-${{ runner.os }}-cargo-build-target
 
     - name: Install Stable
       uses: actions-rs/toolchain@v1

--- a/bin/gen/src/entry.rs
+++ b/bin/gen/src/entry.rs
@@ -24,13 +24,32 @@ impl Entry {
       Metadata::from_commit(commit)?
     };
 
+    fn bytes_to_option(bytes: &[u8]) -> Option<String> {
+      let string = String::from_utf8_lossy(bytes).into_owned();
+      if string.is_empty() {
+        None
+      } else {
+        Some(string)
+      }
+    }
+
+    let name = bytes_to_option(commit.author().name_bytes());
+    let email = bytes_to_option(commit.author().email_bytes());
+
+    let author = match (name, email) {
+      (Some(name), Some(email)) => format!("[{}](mailto:{})", name, email),
+      (Some(name), None) => name,
+      (None, Some(email)) => email,
+      (None, None) => String::from("Anonymous"),
+    };
+
     Entry {
-      version: version.into(),
-      summary: commit.summary().unwrap().into(),
-      author: commit.author().to_string(),
       hash: commit.id().to_string(),
-      metadata,
+      summary: commit.summary().unwrap().into(),
+      version: version.into(),
+      author,
       head,
+      metadata,
       time,
     }
   }


### PR DESCRIPTION
If both author name and email are present for a commit, format as a
link. If one is absent, format as the other. If both are absent, format
as "Anonymous".

type: documentation