### PR TITLE
Don't treat head as special in changelog

### DIFF
--- a/bin/gen/src/changelog.rs
+++ b/bin/gen/src/changelog.rs
@@ -13,8 +13,6 @@ impl Changelog {
 
     let mut entries = Vec::new();
 
-    let mut head = true;
-
     loop {
       let summary_bytes = current
         .summary_bytes()
@@ -37,14 +35,11 @@ impl Changelog {
         let entry = Entry::new(
           &current,
           manifest.package.unwrap().version.as_ref(),
-          head,
           &project.config,
         )?;
 
         entries.push(entry);
       }
-
-      head = false;
 
       match current.parent_count() {
         0 => break,

--- a/bin/gen/src/entry.rs
+++ b/bin/gen/src/entry.rs
@@ -7,12 +7,11 @@ pub(crate) struct Entry {
   hash: String,
   author: String,
   summary: String,
-  head: bool,
 }
 
 impl Entry {
   #[throws]
-  pub(crate) fn new(commit: &Commit, version: &str, head: bool, config: &Config) -> Self {
+  pub(crate) fn new(commit: &Commit, version: &str, config: &Config) -> Self {
     let time = DateTime::<Utc>::from_utc(
       NaiveDateTime::from_timestamp(commit.time().seconds(), 0),
       Utc,
@@ -48,18 +47,13 @@ impl Entry {
       summary: commit.summary().unwrap().into(),
       version: version.into(),
       author,
-      head,
       metadata,
       time,
     }
   }
 
   fn url(&self) -> String {
-    if self.head {
-      "https://github.com/casey/intermodal/commits/master".into()
-    } else {
-      format!("https://github.com/casey/intermodal/commit/{}", self.hash)
-    }
+    format!("https://github.com/casey/intermodal/commit/{}", self.hash)
   }
 
   fn shorthash(&self) -> String {


### PR DESCRIPTION
The changelog is no longer comitted, so we no longer need to avoid
including the commit hash.

type: documentation