### PR TITLE
Suppress all output to stderr if --quiet is passed

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -114,7 +114,7 @@ jobs:
     - name: Install `mdbook`
       uses: peaceiris/actions-mdbook@v1
       with:
-        mdbook-version: latest
+        mdbook-version: '0.4.2'
 
     - name: Build Book
       run: |

--- a/src/env.rs
+++ b/src/env.rs
@@ -61,6 +61,10 @@ impl Env {
       self.out.set_is_term(true);
     }
 
+    if args.options().quiet {
+      self.err.set_active(false);
+    }
+
     args.run(self)
   }
 
@@ -245,6 +249,29 @@ mod tests {
       panic!("Unexpected standard error output: {}", err);
     }
 
+    assert_eq!(env.out(), "");
+  }
+
+  #[test]
+  fn quiet() {
+    let mut env = test_env! {
+      args: [
+        "--quiet",
+        "torrent",
+        "create",
+        "--input",
+        "foo",
+        "--announce",
+        "udp:bar.com",
+        "--announce-tier",
+        "foo",
+      ],
+      tree: {
+        foo: "",
+      }
+    };
+    env.status().ok();
+    assert_eq!(env.err(), "");
     assert_eq!(env.out(), "");
   }
 

--- a/src/subcommand/torrent/create.rs
+++ b/src/subcommand/torrent/create.rs
@@ -315,9 +315,7 @@ impl Create {
       )
     };
 
-    if !options.quiet {
-      CreateStep::Searching { input: &input }.print(env)?;
-    }
+    CreateStep::Searching { input: &input }.print(env)?;
 
     let content = CreateContent::from_create(&self, &input, env)?;
 
@@ -354,9 +352,7 @@ impl Create {
       Some(String::from(consts::CREATED_BY_DEFAULT))
     };
 
-    if !options.quiet {
-      CreateStep::Hashing.print(env)?;
-    }
+    CreateStep::Hashing.print(env)?;
 
     let hasher = Hasher::new(
       self.md5sum,
@@ -374,12 +370,10 @@ impl Create {
       hasher.hash_stdin(&mut env.input())?
     };
 
-    if !options.quiet {
-      CreateStep::Writing {
-        output: &content.output,
-      }
-      .print(env)?;
+    CreateStep::Writing {
+      output: &content.output,
     }
+    .print(env)?;
 
     let info = Info {
       name: content.name,
@@ -449,9 +443,7 @@ impl Create {
       }
     }
 
-    if !options.quiet {
-      errln!(env, "\u{2728}\u{2728} Done! \u{2728}\u{2728}")?;
-    }
+    errln!(env, "\u{2728}\u{2728} Done! \u{2728}\u{2728}")?;
 
     if self.show {
       // We just created this torrent, so no extra fields have been discarded.

--- a/src/subcommand/torrent/verify.rs
+++ b/src/subcommand/torrent/verify.rs
@@ -58,9 +58,7 @@ impl Verify {
       &self.input_flag,
     )?;
 
-    if !options.quiet {
-      VerifyStep::Loading { metainfo: &target }.print(env)?;
-    }
+    VerifyStep::Loading { metainfo: &target }.print(env)?;
 
     let input = env.read(target.clone())?;
 
@@ -86,21 +84,17 @@ impl Verify {
       None
     };
 
-    if !options.quiet {
-      VerifyStep::Verifying { content: &content }.print(env)?;
-    }
+    VerifyStep::Verifying { content: &content }.print(env)?;
 
     let status = metainfo.verify(&env.resolve(content)?, progress_bar)?;
 
     status.print(env)?;
 
     if status.good() {
-      if !options.quiet {
-        errln!(
-          env,
-          "\u{2728}\u{2728} Verification succeeded! \u{2728}\u{2728}"
-        )?;
-      }
+      errln!(
+        env,
+        "\u{2728}\u{2728} Verification succeeded! \u{2728}\u{2728}"
+      )?;
       Ok(())
     } else {
       Err(Error::Verify)

--- a/src/test_env_builder.rs
+++ b/src/test_env_builder.rs
@@ -76,9 +76,10 @@ impl TestEnvBuilder {
       Box::new(out.clone()),
       self.use_color && self.out_is_term,
       self.out_is_term,
+      true,
     );
 
-    let err_stream = OutputStream::new(Box::new(err.clone()), self.err_style, false);
+    let err_stream = OutputStream::new(Box::new(err.clone()), self.err_style, false, true);
 
     let env = Env::new(
       current_dir,


### PR DESCRIPTION
Instead of checking if `options.quiet` is set whenever printing, disable
all printing to stderr if the `--quiet` flag is passed.

Although it isn't strictly necessary, I still don't construct a progress
bar if `options.quiet` is true, since progress bars might be a little
more expensive than just printing error messages.

A future diff might add checking to the `errln` and `outln` macros, so
that they don't print at all if the respective output stream is
inactive.

type: reform