### PR TITLE
Switch mdbook version back to latest

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -114,7 +114,7 @@ jobs:
     - name: Install `mdbook`
       uses: peaceiris/actions-mdbook@v1
       with:
-        mdbook-version: '0.4.2'
+        mdbook-version: latest
 
     - name: Build Book
       run: |


### PR DESCRIPTION
mdbook v0.4.3 release binaries were corrupted, but have been fixed.

type: development