### PR TITLE
Fix publish recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -86,15 +86,14 @@ publish-check: check
 	cargo outdated --exit-code 1
 	grep '^\[{{version}}\]' target/gen/CHANGELOG.md
 
-publish: publish-check
+publish BRANCH=`git rev-parse --abbrev-ref HEAD`: publish-check (merge BRANCH)
 	#!/usr/bin/env bash
 	set -euxo pipefail
-	while ! hub ci-status --verbose; do
-		sleep 5
-	done
 	git tag -a {{version}} -m 'Release {{version}}'
 	git push github {{version}}
-	just merge
+	while ! hub ci-status --verbose {{BRANCH}}; do
+		sleep 5
+	done
 	cargo publish
 
 # record, upload, and render demo animation


### PR DESCRIPTION
Previously, the release branch would be merged after pushing a tag to 
github. This would cause the merge to fail, because github would kick off a
CI run after pushing the tag, and block the merge because it wasn't
finished.

This changes the publish recipe to merge before pushing the tag, which 
aboves the above problem.

type: development