### PR TITLE
Tweak MetainfoDecode error message

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -56,7 +56,7 @@ pub(crate) enum Error {
   },
   #[snafu(display("Failed to serialize torrent metainfo: {}", source))]
   MetainfoSerialize { source: bendy::serde::Error },
-  #[snafu(display("Failed to decode torrent metainfo from {}: {}", input, error))]
+  #[snafu(display("Failed to decode metainfo bencode from {}: {}", input, error))]
   MetainfoDecode {
     input: InputTarget,
     error: bendy::decoding::Error,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
   clippy::map_unwrap_or,
   clippy::missing_docs_in_private_items,
   clippy::missing_inline_in_public_items,
+  clippy::needless_lifetimes,
   clippy::needless_pass_by_value,
   clippy::non_ascii_literal,
   clippy::pattern_type_mismatch,


### PR DESCRIPTION
Tweak the `MetainfoDecode` error message to make it different from the
`MetainfoDeserialize` error message. It's a fine distinction, but the
`MetainfoDeserialize` error message happens on any serde error when
deserializing, whereas the `MetainfoDecode` error message happens when
encountering invalid bencode.

Also placate Clippy by disabling `clippy::needless_lifetimes` lint.

type: reform