### PR TITLE
Skip generating changelog in tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,13 +43,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      if: github.event_name == 'pull_request'
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
-        fetch-depth: 0
-
-    - uses: actions/checkout@v2
-      if: github.event_name != 'pull_request'
       with:
         fetch-depth: 0
 
@@ -115,7 +108,7 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: |
         brew install help2man
-        cargo run --package gen -- --bin target/debug/imdl all
+        cargo run --package gen -- --bin target/debug/imdl all --no-changelog
         git diff --no-ext-diff --exit-code
 
     - name: Install `mdbook`
@@ -127,7 +120,7 @@ jobs:
     - name: Build Book
       if: matrix.os != 'windows-latest'
       run: |
-        cargo run --package gen -- --bin target/debug/imdl book
+        cargo run --package gen -- --bin target/debug/imdl book --no-changelog
         mdbook build book --dest-dir ../www/book
 
     - name: Record Git Revision

--- a/bin/gen/src/subcommand.rs
+++ b/bin/gen/src/subcommand.rs
@@ -4,21 +4,13 @@ use crate::common::*;
 pub(crate) enum Subcommand {
   #[structopt(about("Update all generated docs"))]
   All {
-    #[structopt(
-      long = "no-git",
-      help = "Skip generated outputs that require a Git repository. Currently this only includes \
-              the changelog."
-    )]
-    no_git: bool,
+    #[structopt(long = "no-changelog", help = "Don't generate the changelog.")]
+    no_changelog: bool,
   },
   #[structopt(about("Generate book"))]
   Book {
-    #[structopt(
-      long = "no-git",
-      help = "Skip book contents require a Git repository. Currently this only includes the \
-              changelog."
-    )]
-    no_git: bool,
+    #[structopt(long = "no-changelog", help = "Don't generate the changelog.")]
+    no_changelog: bool,
   },
   #[structopt(about("Generate the changelog"))]
   Changelog,
@@ -84,21 +76,21 @@ impl Subcommand {
       }
       Self::CompletionScripts => Self::completion_scripts(&project)?,
       Self::Readme => Self::readme(&project)?,
-      Self::Book { no_git } => Self::book(&project, no_git)?,
+      Self::Book { no_changelog } => Self::book(&project, no_changelog)?,
       Self::Man => Self::man(&project)?,
       Self::Diff => Self::diff(&project)?,
-      Self::All { no_git } => Self::all(&project, no_git)?,
+      Self::All { no_changelog } => Self::all(&project, no_changelog)?,
     }
   }
 
   #[throws]
-  pub(crate) fn all(project: &Project, no_git: bool) {
-    if !no_git {
+  pub(crate) fn all(project: &Project, no_changelog: bool) {
+    if !no_changelog {
       Self::changelog(&project)?;
     }
     Self::completion_scripts(&project)?;
     Self::readme(&project)?;
-    Self::book(&project, no_git)?;
+    Self::book(&project, no_changelog)?;
     Self::man(&project)?;
   }
 
@@ -195,7 +187,7 @@ impl Subcommand {
   }
 
   #[throws]
-  pub(crate) fn book(project: &Project, no_git: bool) {
+  pub(crate) fn book(project: &Project, no_changelog: bool) {
     info!("Generating book…");
 
     let gen = project.gen()?;
@@ -230,11 +222,11 @@ impl Subcommand {
 
     Introduction::new(&project.config).render_to(out.join("introduction.md"))?;
 
-    let include_changelog = !no_git;
+    let include_changelog = !no_changelog;
 
     Summary::new(project, include_changelog).render_to(out.join("SUMMARY.md"))?;
 
-    if !no_git {
+    if !no_changelog {
       let changelog = Changelog::new(&project)?;
       let dst = out.join("changelog.md");
       fs::write(&dst, changelog.render(true)?).context(error::Filesystem { path: dst })?;


### PR DESCRIPTION
Changelog generation requires annotating commits with a commit type,
otherwise the tests will fail. This is annoying for contributors, since
it's unusual, and I often myself forget to do it, causing a round-trip
with tests.

So, skip generating the changelog during the tests. Also, change the
`--no-git` option for `gen book` and `gen all` to `--no-changelog`, so
it's clearer what it does.

I think I'll wind up just making a YAML file that contains commit types,
for changelog generation, so it doesn't have to be done in the commit
message.

type: testing