### PR TITLE
Docs: consolidate piece selection algorithm from docs with actual implementation

### DIFF
--- a/book/src/bittorrent/piece-length.md
+++ b/book/src/bittorrent/piece-length.md
@@ -58,7 +58,7 @@ MIN = 16 * 1024
 MAX = 16 * 1024 * 1024
 
 def piece_length(content_length):
-  exponent = math.log2(content_length)
+  exponent = math.ceil(math.log2(content_length))
   length = 1 << int((exponent / 2 + 4))
   return min(max(length, MIN), MAX)
 ```


### PR DESCRIPTION
See title.

Also, what's the reason for writing...

```python
length = 1 << int((exponent / 2 + 4))
```

...instead of?

```python
length = 16 << int(exponent / 2)
```

