### PR TITLE
feat: add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM docker.io/lukemathwalker/cargo-chef:latest-rust-latest as chef
+
+WORKDIR /app
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+COPY . .
+RUN cargo build --release
+
+FROM gcr.io/distroless/cc-debian12:nonroot AS runtime
+COPY --from=builder /app/target/release/imdl /imdl
+ENTRYPOINT ["/imdl"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ COPY . .
 RUN cargo build --release
 
 FROM gcr.io/distroless/cc-debian12:nonroot AS runtime
-COPY --from=builder /app/target/release/imdl /imdl
-ENTRYPOINT ["/imdl"]
+COPY --from=builder /app/target/release/imdl /usr/local/bin/imdl
+ENTRYPOINT ["/usr/local/bin/imdl"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
-FROM docker.io/library/rust:1.78.0-bookworm as builder
+FROM docker.io/library/rust:1.78.0-bookworm AS builder
 
-WORKDIR /app
+WORKDIR /usr/local/src
+
 COPY . .
+
 RUN cargo build --release
 
-FROM gcr.io/distroless/cc-debian12:nonroot AS runtime
-COPY --from=builder /app/target/release/imdl /usr/local/bin/imdl
+FROM gcr.io/distroless/cc-debian12:nonroot
+
+COPY --from=builder /usr/local/src/target/release/imdl /usr/local/bin/imdl
+
 ENTRYPOINT ["/usr/local/bin/imdl"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,7 @@
-FROM docker.io/lukemathwalker/cargo-chef:latest-rust-latest as chef
+FROM docker.io/library/rust:latest as builder
 
 WORKDIR /app
 
-FROM chef AS planner
-COPY . .
-RUN cargo chef prepare --recipe-path recipe.json
-
-FROM chef AS builder
-COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
 RUN cargo build --release
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/rust:latest as builder
+FROM docker.io/library/rust:1.78.0-bookworm as builder
 
 WORKDIR /app
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM docker.io/library/rust:latest as builder
 
 WORKDIR /app
-
 COPY . .
 RUN cargo build --release
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ If it does not, please open an issue!
 | [Arch Linux](https://www.archlinux.org)                              | Manual Installation                                | [intermodal](https://aur.archlinux.org/packages/intermodal)<sup>AUR</sup>                         | [wiki](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages) |
 | [Void Linux](https://voidlinux.org)                                  | [XBPS](https://docs.voidlinux.org/xbps/index.html) | [intermodal](https://github.com/void-linux/void-packages/blob/master/srcpkgs/intermodal/template) | `xbps-install -S intermodal`                                                          |
 | [Windows](https://www.microsoft.com/en-us/windows)                   | [Scoop](https://scoop.sh)                          | [intermodal](https://github.com/ScoopInstaller/Main/blob/master/bucket/intermodal.json)           | `scoop install intermodal`                                                            |
-| [Docker](https://www.docker.com/)                   | [Cargo](https://www.rust-lang.org)                          | [intermodal](https://github.com/casey/intermodal/blob/master/Dockerfile)           | `docker pull ghcr.io/casey/intermodal`                                                            |
 
 ### Pre-built binaries
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ If it does not, please open an issue!
 | [Arch Linux](https://www.archlinux.org)                              | Manual Installation                                | [intermodal](https://aur.archlinux.org/packages/intermodal)<sup>AUR</sup>                         | [wiki](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages) |
 | [Void Linux](https://voidlinux.org)                                  | [XBPS](https://docs.voidlinux.org/xbps/index.html) | [intermodal](https://github.com/void-linux/void-packages/blob/master/srcpkgs/intermodal/template) | `xbps-install -S intermodal`                                                          |
 | [Windows](https://www.microsoft.com/en-us/windows)                   | [Scoop](https://scoop.sh)                          | [intermodal](https://github.com/ScoopInstaller/Main/blob/master/bucket/intermodal.json)           | `scoop install intermodal`                                                            |
+| [Docker](https://www.docker.com/)                   | [Cargo](https://www.rust-lang.org)                          | [intermodal](https://github.com/casey/intermodal/blob/master/Dockerfile)           | `docker pull ghcr.io/casey/intermodal`                                                            |
 
 ### Pre-built binaries
 

--- a/justfile
+++ b/justfile
@@ -134,3 +134,7 @@ get-torrents:
 # download bittorrent.org repository
 get-beps:
 	git clone git@github.com:bittorrent/bittorrent.org.git tmp/bittorrent.org
+
+build-image:
+  podman build -t imdl:master .
+  podman run imdl:master

--- a/justfile
+++ b/justfile
@@ -136,5 +136,5 @@ get-beps:
 	git clone git@github.com:bittorrent/bittorrent.org.git tmp/bittorrent.org
 
 build-image:
-  podman build -t imdl:master .
-  podman run imdl:master
+  podman build -t imdl .
+  podman run imdl


### PR DESCRIPTION
Containerizing intermodal makes it easier to use without installing it. 

The docker image can be hosted on ghcr.io and its build automated via github action:
https://docs.github.com/en/actions/publishing-packages/publishing-docker-images

The container can then be used like this:
```bash
docker run --rm --init --interactive --tty --volume "$(pwd)":/mnt ghcr.io/casey/intermodal torrent show /mnt/example.torrent
```

