### PR TITLE
Allow `--output` to be a directory

### DIFF
--- a/src/subcommand/torrent/create/create_content.rs
+++ b/src/subcommand/torrent/create/create_content.rs
@@ -61,10 +61,16 @@ impl CreateContent {
             .to_owned(),
         };
 
-        let output = create
+        let mut output = create
           .output
           .clone()
           .unwrap_or_else(|| OutputTarget::Path(Self::torrent_path(path, &name)));
+
+        if let OutputTarget::Path(path) = &output {
+          if path.is_dir() {
+            output = OutputTarget::Path(path.join(format!("{name}.torrent")));
+          }
+        }
 
         Ok(Self {
           files: Some(files),


### PR DESCRIPTION
Currently, when the `--output` flag to `torrent create` is a directory, imdl errors out with "error: Output path already exists".

With this change, it will create a torrent file with the default name, but in the specified directory.

```sh
$ mkdir out
$ imdl torrent create src --output out
[1/3] 🧿 Searching `src` for files…
[2/3] 🧮 Hashing pieces…
[3/3] 💾 Writing metainfo to `out/src.torrent`…
✨✨ Done! ✨✨
$ ls out
src.torrent
```

Resolves #525 