### PR TITLE
Torrent creation: add support for mtime-based file sorting

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -62,6 +62,8 @@ pub(crate) enum Error {
     input: InputTarget,
     source: MetainfoError,
   },
+  #[snafu(display("Modification time invalid/missing"))]
+  ModificationTimeMissing,
   #[snafu(display("Network error: {}", source))]
   Network { source: io::Error },
   #[snafu(display("Failed to invoke opener: {}", source))]

--- a/src/file_info.rs
+++ b/src/file_info.rs
@@ -9,11 +9,11 @@ pub(crate) struct FileInfo {
     default,
     with = "unwrap_or_skip"
   )]
-  pub(crate) mtime: Option<SystemTime>,
+  pub(crate) md5sum: Option<Md5Digest>,
   #[serde(
     skip_serializing_if = "Option::is_none",
     default,
     with = "unwrap_or_skip"
   )]
-  pub(crate) md5sum: Option<Md5Digest>,
+  pub(crate) mtime: Option<SystemTime>,
 }

--- a/src/file_info.rs
+++ b/src/file_info.rs
@@ -9,5 +9,11 @@ pub(crate) struct FileInfo {
     default,
     with = "unwrap_or_skip"
   )]
+  pub(crate) mtime: Option<SystemTime>,
+  #[serde(
+    skip_serializing_if = "Option::is_none",
+    default,
+    with = "unwrap_or_skip"
+  )]
   pub(crate) md5sum: Option<Md5Digest>,
 }

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -73,6 +73,7 @@ impl Hasher {
 
       files.push(FileInfo {
         path: file_path.clone(),
+        mtime: None,
         md5sum,
         length,
       });

--- a/src/metainfo.rs
+++ b/src/metainfo.rs
@@ -171,6 +171,7 @@ impl Metainfo {
       files: vec![FileInfo {
         length: Bytes(32 * 1024),
         path: FilePath::from_components(&["DIR", "FILE"]),
+        mtime: None,
         md5sum: Some(Md5Digest::from_hex("000102030405060708090a0b0c0d0e0f")),
       }],
     };
@@ -231,6 +232,7 @@ impl Metainfo {
         mode: Mode::Multiple {
           files: vec![FileInfo {
             length: Bytes(1024),
+            mtime: None,
             md5sum: None,
             path: FilePath::from_components(&["a", "b"]),
           }],

--- a/src/mode.rs
+++ b/src/mode.rs
@@ -86,6 +86,7 @@ mod tests {
         length: Bytes(10),
         path: FilePath::from_components(&["foo", "bar"]),
         md5sum: Some(Md5Digest::from_hex("000102030405060708090a0b0c0d0e0f")),
+        mtime: None,
       }],
     };
 

--- a/src/sort_key.rs
+++ b/src/sort_key.rs
@@ -5,6 +5,7 @@ use crate::common::*;
 pub(crate) enum SortKey {
   Path,
   Size,
+  Mtime,
 }
 
 impl SortKey {

--- a/src/sort_spec.rs
+++ b/src/sort_spec.rs
@@ -1,4 +1,5 @@
 use crate::common::*;
+use snafu::OptionExt;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) struct SortSpec {
@@ -25,7 +26,10 @@ impl SortSpec {
     let ordering = match self.key {
       SortKey::Path => a.path.cmp(&b.path),
       SortKey::Size => a.length.cmp(&b.length),
-      SortKey::Mtime => a.mtime.cmp(&b.mtime),
+      SortKey::Mtime => {
+        a.mtime.context(error::ModificationTimeMissing).unwrap()
+          .cmp(&b.mtime.context(error::ModificationTimeMissing).unwrap())
+      }
     };
 
     match self.order {

--- a/src/sort_spec.rs
+++ b/src/sort_spec.rs
@@ -25,6 +25,7 @@ impl SortSpec {
     let ordering = match self.key {
       SortKey::Path => a.path.cmp(&b.path),
       SortKey::Size => a.length.cmp(&b.length),
+      SortKey::Mtime => a.mtime.cmp(&b.mtime),
     };
 
     match self.order {

--- a/src/subcommand/torrent/create.rs
+++ b/src/subcommand/torrent/create.rs
@@ -187,7 +187,7 @@ Examples:
     long = "sort-by",
     value_name = "SPEC",
     help = "Set the order of files within a torrent. `SPEC` should be of the form `KEY:ORDER`, \
-            with `KEY` being one of `path` or `size`, and `ORDER` being `ascending` or \
+            with `KEY` being one of `path`, `size` or `mtime`, and `ORDER` being `ascending` or \
             `descending`. `:ORDER` defaults to `ascending` if omitted. The `--sort-by` flag may \
             be given more than once, with later values being used to break ties. Ties that remain \
             are broken in ascending path order.
@@ -1274,11 +1274,13 @@ mod tests {
             path: FilePath::from_components(&["bar"]),
             length: Bytes(4),
             md5sum: Some(Md5Digest::from_data("5678")),
+            mtime: None,
           },
           FileInfo {
             path: FilePath::from_components(&["foo"]),
             length: Bytes(4),
             md5sum: Some(Md5Digest::from_data("1234")),
+            mtime: None,
           },
         ],
       }
@@ -1422,6 +1424,7 @@ mod tests {
           &[FileInfo {
             length: Bytes(3),
             md5sum: Some(Md5Digest::from_hex("37b51d194a7513e45b56f6524f2d51f2")),
+            mtime: None,
             path: FilePath::from_components(&["bar"]),
           },]
         );
@@ -1457,6 +1460,7 @@ mod tests {
           &[FileInfo {
             length: Bytes(3),
             md5sum: None,
+            mtime: None,
             path: FilePath::from_components(&["bar"]),
           },]
         );
@@ -1495,16 +1499,19 @@ mod tests {
           &[
             FileInfo {
               length: Bytes(3),
+              mtime: None,
               md5sum: Some(Md5Digest::from_hex("900150983cd24fb0d6963f7d28e17f72")),
               path: FilePath::from_components(&["a"]),
             },
             FileInfo {
               length: Bytes(3),
+              mtime: None,
               md5sum: Some(Md5Digest::from_hex("857c4402ad934005eae4638a93812bf7")),
               path: FilePath::from_components(&["h"]),
             },
             FileInfo {
               length: Bytes(3),
+              mtime: None,
               md5sum: Some(Md5Digest::from_hex("d16fb36f0911f878998c136191af705e")),
               path: FilePath::from_components(&["x"]),
             },
@@ -1993,11 +2000,13 @@ Content Size  9 bytes
             FileInfo {
               length: Bytes(3),
               md5sum: Some(Md5Digest::from_hex("37b51d194a7513e45b56f6524f2d51f2")),
+              mtime: None,
               path: FilePath::from_components(&["bar"]),
             },
             FileInfo {
               length: Bytes(3),
               md5sum: Some(Md5Digest::from_hex("73feffa4b7f6bb68e44cf984c85f6e88")),
+              mtime: None,
               path: FilePath::from_components(&["dir", "baz"]),
             },
           ]

--- a/src/walker.rs
+++ b/src/walker.rs
@@ -155,6 +155,7 @@ impl Walker {
       file_infos.push(FileInfo {
         path: file_path,
         length: Bytes(len),
+        mtime: metadata.modified().ok(),
         md5sum: None,
       });
     }


### PR DESCRIPTION
This can be useful for file collections that are periodically updated, so that the new files are appended to the end of the torrent, and the piece boundaries for the old ones are intact.